### PR TITLE
Add Project Pages

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,7 @@
+class ProjectsController < ApplicationController
+
+  def show
+    @project = Project.find_by_id(params[:id])
+    @related_projects = @project.related_projects
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,4 +6,9 @@ class Project < ActiveRecord::Base
   def github_url
     github_url = "http://github.com/" + self.organization.github_org + "/" + self.github_repo
   end  
+
+  def related_projects
+    projects = self.organization.projects.where("id NOT IN (?)", self.id)
+  end
+
 end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,0 +1,22 @@
+<body>
+  
+  <h4><%= link_to @project.name, @project.github_url, :target => "_blank" %></h4>
+
+  <div id="summary">
+    <% if @project.organization.image_url !="" %>
+      <img src=<%= @project.organization.image_url %> alt=<%= @project.organization.name %>/>
+    <% end %>
+    <p><%= @project.organization.description %></p>
+  </div>
+
+  <% if @related_projects.exists? %>
+    <div id="related_projects">
+      <h5>Related Projects</h5>
+    
+      <% @related_projects.each do |project| %>
+        <h6><%= link_to project.name, project_path(project) %></h6>
+      <% end %>
+    </div>
+  <% end %>
+  
+</body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ CodeMontage::Application.routes.draw do
   # Organizations and project information
   resources :organizations
   get '/projects', {:controller => 'organizations', :action => 'index'}
+  resources :projects, :only => [:show]
   
   # Static content 
   get '/apply', {:controller => 'home', :action => 'apply'}


### PR DESCRIPTION
Adds individual project pages at /projects/[:id], complete with links to Github and related projects (within the same organization, for now).
