### PR TITLE
Handle logged out users better

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,13 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     projects_path
   end
-  
+
   def after_sign_out_path_for(resource_or_scope) #return to page you logged out from
     request.referrer
   end
 
   def authenticate_admin_user! #override admin_user default to use user.is_admin
-    redirect_to '/' unless current_user.is_admin? 
+    redirect_to '/' unless current_user.present? && current_user.is_admin? 
     authenticate_user! 
   end 
 
@@ -19,4 +19,8 @@ class ApplicationController < ActionController::Base
     current_user 
   end 
 
+  def login_required
+    redirect_to '/' unless current_user.present?
+    return false
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,8 @@
 class HomeController < ApplicationController
 
+  before_filter :login_required, :only => :dashboard
+
   def dashboard
-    redirect_to '/' unless user_signed_in?
     @favorite_projects = current_user.favorites
   end
 


### PR DESCRIPTION
When they try to reach areas they need to be logged in to access.

Using a `before_filter` is the best practise for this, but we can't do that for the rails admin stuff so we just check that current_user is present before checking to see if it has admin access.
