### PR TITLE
Added the quiet_assets gem in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,11 @@ group :test do
   gem 'shoulda-matchers'
 end
 
+# Development helpers
+group :development do
+  gem 'quiet_assets'
+end
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
       activerecord (~> 3.0)
     polyglot (0.3.3)
     psych (1.3.4)
+    quiet_assets (1.0.2)
+      railties (>= 3.1, < 5.0)
     rack (1.4.3)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -232,6 +234,7 @@ DEPENDENCIES
   omniauth-github
   pg
   psych
+  quiet_assets
   rails (= 3.2.11)
   rspec-rails
   sass-rails (~> 3.2.3)


### PR DESCRIPTION
It removes logging of all asset loads in development, greatly cleaning up the log output.
