### PR TITLE
Keep Zurb Foundation v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :assets do
   # Foundation front-end framework
   gem 'compass-rails'
   gem 'foundation-icons-sass-rails'
-  gem 'zurb-foundation'
+  gem 'zurb-foundation', '3.2.5'
 
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   # gem 'therubyracer', :platforms => :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
       activesupport (~> 3.1)
       polyamorous (~> 0.5.0)
     mime-types (1.22)
+    modular-scale (1.0.6)
+      compass (>= 0.12.1)
+      sass (>= 3.2.0)
+      sassy-math (>= 1.5)
     multi_json (1.7.2)
     multipart-post (1.2.0)
     oauth2 (0.8.1)
@@ -178,6 +182,8 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    sassy-math (1.5)
+      compass (~> 0.11)
     shoulda-matchers (2.0.0)
       activesupport (>= 3.0.0)
     simple_form (2.1.0)
@@ -199,7 +205,10 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
     warden (1.2.1)
       rack (>= 1.0)
-    zurb-foundation (4.1.2)
+    zurb-foundation (3.2.5)
+      compass (>= 0.12.2)
+      modular-scale (= 1.0.6)
+      rake
       sass (>= 3.2.0)
 
 PLATFORMS
@@ -226,4 +235,4 @@ DEPENDENCIES
   shoulda-matchers
   simple_form
   uglifier (>= 1.0.3)
-  zurb-foundation
+  zurb-foundation (= 3.2.5)


### PR DESCRIPTION
Zurb Foundation is at version 4 now, but there are a whole lot of changes, so lock this in at 3.2.5 until we're ready to make the full upgrade.
