### PR TITLE
Fix #72 gmaps symbol typo breaking user auth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
   after_validation :geocode, :reverse_geocode, :if => :current_sign_in_ip_changed?
 
   # Location mapping
-  acts_as_gmappable :process_geocoding => :false #processed by geocoder, no need to repeat
+  acts_as_gmappable :process_geocoding => false #processed by geocoder, no need to repeat
 
   scope :with_github, where(Service.where('services.user_id = users.id AND provider = ?', "github").exists)
   


### PR DESCRIPTION
Fixes #72
![codemontage-2](https://f.cloud.github.com/assets/226228/931839/269486f4-0035-11e3-9b72-023d621987bd.jpg)
