### PR TITLE
removes autofocus from account settings email address field

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <body>
-  
+
   <%= render "devise/registrations/profile" %>
 
   <section id="user_settings">
@@ -9,7 +9,7 @@
       <%= f.error_notification %>
 
       <div class="form-inputs">
-        <%= f.input :email, :required => true, :autofocus => true %>
+        <%= f.input :email, :required => true %>
         <%= f.input :password, :autocomplete => "off", :placeholder => "(leave blank to keep your current password)", :required => false %>
         <%= f.input :current_password, :required => true %>
       </div>


### PR DESCRIPTION
Depending on the type of form devise renders it seems to add the autofocus attribute to the first input.  I removed this for the email address field on the account settings page.
