### PR TITLE
Upgrade to Ruby 2.0 (2.0.0p353)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.0.0"
 
 # Admin Tools
 gem 'activeadmin'


### PR DESCRIPTION
Requires Ruby 2.0 (2.0.0p353) in response to [Ruby Security Vulnerability CVE-2013-4164](http://lists.heroku.com/t/ViewEmail/r/4AC4716696A139E82540EF23F30FEDED/DD5A15BCF114233FF351F20C80B74D5E)

Succesfully triggered update on Heroku staging and production environments:
![ruby2 0update](https://f.cloud.github.com/assets/226228/1605842/dfd985bc-53f8-11e3-8ad9-a7e4fc7be8ac.png)
