### PR TITLE
Tweak submission language to remain consistent with homepage call to action

### DIFF
--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,6 +1,6 @@
 <body>
   
-  <h2>Submit Your Project</h2>
+  <h2>Submit a Project</h2>
 
   <%= simple_form_for @organization do |f| %>  
   	<div class="form-inputs">
@@ -22,10 +22,10 @@
     </div>
 
     <div class="form-actions">
-    	<%= f.button :submit, 'Submit Your Project', :class => "small radius button" %>
+    	<%= f.button :submit, 'Submit a Project', :class => "small radius button" %>
     </div>
   <% end %>
 
-  <p>Already a CodeMontage Organization? <%= mail_to "projects@codemontage.com", "Submit Your New Project", :subject => "New project for my organization" %></p>
+  <p>Already a CodeMontage Organization? <%= mail_to "projects@codemontage.com", "Submit a New Project", :subject => "New project for my organization" %></p>
 
 </body>


### PR DESCRIPTION
Changes "Submit Your Project/Submit Your New Project" in the project submission form to "Submit a Project/Submit a New Project", as used on the home page and suggested in #122.

![image](https://f.cloud.github.com/assets/2766324/1827434/21d607ca-7234-11e3-8b63-b6885c06eb37.png)
