### PR TITLE
Fixes #135, Do not require GitHub Organization for orgs created via Admin

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -7,6 +7,7 @@ class OrganizationsController < ApplicationController
 
 	def create
 		@organization = Organization.new(params[:organization])
+		@organization.is_public_user = true
 
 		if @organization.save
 			redirect_to root_path, :notice => "Your project has been submitted for approval."

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,10 @@ class Organization < ActiveRecord::Base
   attr_accessible :name, :url, :github_org, :description, :is_tax_exempt, :contact_name, :contact_role, :contact_email, :annual_budget_usd, :total_staff_size, :tech_staff_size, :notes, :image_url, :twitter, :logo, :logo_delete
   attr_accessible :organization_metrics_attributes, :projects_attributes
 
-  validates_presence_of :name, :github_org
+  attr_accessor :is_public_user
+
+  validates_presence_of :name
+  validates_presence_of :github_org, :if => :is_public_user
 
   #Paperclip
   has_attached_file :logo, :styles => { :thumb => "100x100>", :medium => "250x250>" },

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -4,5 +4,18 @@ describe Organization do
   it { should have_many(:organization_metrics) }
   it { should have_many(:projects) }
   it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:github_org) }
+
+  context 'if public user' do
+    before { subject.stub(:is_public_user){true} }
+    it { should validate_presence_of(:github_org) }
+  end
+
+  context 'if not public user' do
+    before { subject.stub(:is_public_user){false} }
+    it { should_not validate_presence_of(:github_org) }
+  end
+
+  context 'if not public user, implicit' do
+    it { should_not validate_presence_of(:github_org) }
+  end
 end


### PR DESCRIPTION
Validations are done on the model level and due to separation of concern it does not have, and should not have any dependency to the controller. The workaround in this fix is to add and attribute is_public_user to the organization model. This attribute controls the validation state. The public organization controller sets the attribute on the model to enable validation of github_org attribute.
