### PR TITLE
Issue 123: Add unapproved projects filter

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -18,6 +18,17 @@ ActiveAdmin.register Project do
     default_actions
   end
   
+  filter :organization
+  filter :name
+  filter :github_repo
+  filter :description
+  filter :notes
+  filter :created_at
+  filter :updated_at
+  filter :is_active
+  filter :slug
+  filter :is_approved, :as => :select
+
   form do |f|
     f.inputs "Project Details", :multipart => true do    
       f.input :organization


### PR DESCRIPTION
Issue #123
- Added the ability to filter projects by approved/unapproved. Changed Approved checkbox to select with options 'any', 'yes', 'no'.
- Adding a custom filter and preserving the order of existing filters
  required overriding of the default filters and declaring them manually

![screen shot 2014-01-21 at 9 31 49 pm](https://f.cloud.github.com/assets/85859/1967955/5d671916-82db-11e3-9336-83a1eb7e3d9c.png)
