### PR TITLE
Fixes #135, Do not require GitHub Organization for orgs created via Admin

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -7,7 +7,7 @@ class OrganizationsController < ApplicationController
 
 	def create
 		@organization = Organization.new(params[:organization])
-		@organization.is_public_user = true
+		@organization.is_public_submission = true
 
 		if @organization.save
 			redirect_to root_path, :notice => "Your project has been submitted for approval."

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,10 +9,10 @@ class Organization < ActiveRecord::Base
   attr_accessible :name, :url, :github_org, :description, :is_tax_exempt, :contact_name, :contact_role, :contact_email, :annual_budget_usd, :total_staff_size, :tech_staff_size, :notes, :image_url, :twitter, :logo, :logo_delete
   attr_accessible :organization_metrics_attributes, :projects_attributes
 
-  attr_accessor :is_public_user
+  attr_accessor :is_public_submission
 
   validates_presence_of :name
-  validates_presence_of :github_org, :if => :is_public_user
+  validates_presence_of :github_org, :if => :is_public_submission
 
   #Paperclip
   has_attached_file :logo, :styles => { :thumb => "100x100>", :medium => "250x250>" },

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -5,17 +5,17 @@ describe Organization do
   it { should have_many(:projects) }
   it { should validate_presence_of(:name) }
 
-  context 'if public user' do
-    before { subject.stub(:is_public_user){true} }
+  context 'if public submission' do
+    before { subject.stub(:is_public_submission){true} }
     it { should validate_presence_of(:github_org) }
   end
 
-  context 'if not public user' do
-    before { subject.stub(:is_public_user){false} }
+  context 'if not public submission' do
+    before { subject.stub(:is_public_submission){false} }
     it { should_not validate_presence_of(:github_org) }
   end
 
-  context 'if not public user, implicit' do
+  context 'if not public submission, implicit' do
     it { should_not validate_presence_of(:github_org) }
   end
 end


### PR DESCRIPTION
### Do not require GitHub Organization for orgs created via Admin

This is a `github_org_requirement` branch version of an awesome refactor submitted by @pschlund (#158), covering a few bases:
- No longer requires GitHub org by default for new organizations (e.g. those created in Admin)
- Continues to require GitHub org for projects submitted on [the project submission page](http://www.codemontage.com/organizations/new)
- Adds appropriate tests for public project submission

The UX on this could be improved across the site (see #170), but it works!
![codemontageorgsubmissionpublic_githubreq-5](https://f.cloud.github.com/assets/226228/2059499/c4ccf04e-8bb4-11e3-9dc1-18507097bbe6.png)
