### PR TITLE
Fixes #123 Show Unapproved Project Submission on Admin Dashboard

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -13,6 +13,14 @@ ActiveAdmin.register_page "Dashboard" do
             li link_to Project.count.to_s + " Projects", admin_projects_path
           end
         end
+
+        panel "Unapproved Projects", :priority => 4 do
+          ul do
+            Project.where(is_approved: false).map do |proj|
+              li link_to(proj.name, admin_project_path(proj))
+            end
+          end
+        end
       end
       
       column do # Users


### PR DESCRIPTION
### Add Unapproved Projects to the main Admin dashboard

Fixes #123
![dashboard___code_montage-6](https://f.cloud.github.com/assets/226228/2059773/18e7eeea-8bd3-11e3-87f7-c7d8c0046c56.png)
