### PR TITLE
Wrapped active jobs scope in callable block to prevent eager evaluation

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -5,6 +5,6 @@ class Job < ActiveRecord::Base
   
   attr_accessible :apply_url, :expires_at, :organization_id, :overview, :title, :location, :cause_list, :technology_list
   
-  scope :active, where(['expires_at IS NULL OR expires_at > ?', DateTime.now])
+  scope :active, -> { where(['expires_at IS NULL OR expires_at > ?', DateTime.now]) }
   
 end


### PR DESCRIPTION
Wrapped active jobs scope in callable block to prevent eager eval. - since DateTime.now is involved. 
