### PR TITLE
eager-loaded organizations to prevent N+1 Queries in projects and jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,7 +1,7 @@
 class JobsController < ApplicationController
 
   def index
-    @active_jobs = Job.active
+    @active_jobs = Job.active.with_org_name_url
     @hiring_orgs = Organization.hiring
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController
         Project.featured.tagged_with(params[:tags], :any => true) 
       else 
         Project.featured 
-      end
+      end.with_organization_twitter
     @favorite_projects = 
       if current_user.present?
         FavoriteProject.where(:user_id => current_user.id).map {|p| p.project_id }.to_set

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -6,5 +6,5 @@ class Job < ActiveRecord::Base
   attr_accessible :apply_url, :expires_at, :organization_id, :overview, :title, :location, :cause_list, :technology_list
   
   scope :active, where(['expires_at IS NULL OR expires_at > ?', DateTime.now])
-  
+  scope :with_org_name_url, eager_load(:organization).select("jobs.*, organizations.name, organizations.url")
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,7 @@ class Project < ActiveRecord::Base
   scope :approved, where(:is_approved => true)
   scope :active, approved.where(:is_active => true)
   scope :featured, where("organization_id IS NOT NULL").active
+  scope :with_organization_twitter, eager_load(:organization).select("projects.*, organizations.twitter")
   
   def github_display
     github_display = self.organization.github_org + "/" + self.github_repo


### PR DESCRIPTION
Added an eager load query and selected require fields in organizations for Projects and Jobs listing pages to prevent N+1 queries hitting the database. 
## 

_Steve_
_midnight foxes of [@spritle-dev-team](https://github.com/orgs/spritlesoftware/teams/spritle-dev-team)_
