### PR TITLE
Set Up Travis for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.0.0-p353
+script: bundle exec rake db:drop db:create db:migrate db:test:prepare spec
+notifications:
+  email: false
+
+before_script:
+  - 'cp ./config/database.yml.sample ./config/database.yml'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ##Welcome to the CodeMontage Platform
+[![Build Status](https://travis-ci.org/CodeMontageHQ/codemontage.png)](https://travis-ci.org/CodeMontageHQ/codemontage)
 
 **[CodeMontage](http://codemontage.com) empowers coders to improve their impact on the world.**
 


### PR DESCRIPTION
Adds Travis CI support for the codemontage application, so we will have an automated, GitHub-integrated way to verify all tests are passing with each new version of the codebase.

[Travis CI](http://en.wikipedia.org/wiki/Travis_CI) is a hosted, distributed continuous integration service used to build and test projects hosted at GitHub. Travis CI is currently [free for all open source projects](http://travis-ci.com/plans).
#### On Travis-CI.org

![travis_ci_-_free_hosted_continuous_integration_platform_for_the_open_source_community_and_alex_gessner-5](https://f.cloud.github.com/assets/226228/2118522/f5c339c0-910d-11e3-8a2b-9b30b48faae6.png)
#### On GitHub at CodeMontageHQ/codemontage

![codemontagehq_codemontage](https://f.cloud.github.com/assets/226228/2118557/45ff47b0-9110-11e3-9c5e-ae872009019b.png)

Fixes #101 
