### PR TITLE
Preloaded Organizations in Projects Index

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,7 @@ class ProjectsController < ApplicationController
         Project.featured.tagged_with(params[:tags], :any => true) 
       else 
         Project.featured 
-      end.includes :technologies, :causes
+      end.with_technologies_and_causes.with_organization
 
     @favorite_projects = 
       if current_user.present?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,9 @@ class Project < ActiveRecord::Base
   scope :approved, where(:is_approved => true)
   scope :active, approved.where(:is_active => true)
   scope :featured, where("organization_id IS NOT NULL").active
-  
+  scope :with_technologies_and_causes, includes(:technologies, :causes  )
+  scope :with_organization, includes(:organization)
+
   def github_display
     github_display = self.organization.github_org + "/" + self.github_repo
   end


### PR DESCRIPTION
Preloaded organizations in `projects/index` thereby avoiding N+1 queries. 

Initially there was some concerns in loading many organization records into the memory but as @DBNess said, pagination will be used in future which rules out most issues. #178

Also, refactored the preloading of `technologies` and `causes` into a scope.
