### PR TITLE
Preload organizations in jobs page

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,7 +1,7 @@
 class JobsController < ApplicationController
 
   def index
-    @active_jobs = Job.active
+    @active_jobs = Job.active.with_organization
     @hiring_orgs = Organization.hiring
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -6,5 +6,5 @@ class Job < ActiveRecord::Base
   attr_accessible :apply_url, :expires_at, :organization_id, :overview, :title, :location, :cause_list, :technology_list
   
   scope :active, -> { where(['expires_at IS NULL OR expires_at > ?', DateTime.now]) }
-  
+  scope :with_organization, -> { includes(:organization) }
 end


### PR DESCRIPTION
Preloaded organizations in `jobs/index` thereby avoiding N+1 queries. 

`includes` is okay because pagination would be used soon. 
