### PR TITLE
added github link in header

### DIFF
--- a/app/assets/stylesheets/header.css.scss
+++ b/app/assets/stylesheets/header.css.scss
@@ -24,3 +24,6 @@
   height: 80px; 
   ul.inline-list { margin-bottom: 10px; }
 }
+ul.inline-list .fi-social-github {
+  vertical-align: top;
+}

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,6 +10,7 @@
           <li class="social_media"><%= link_to '<i class="fi-social-twitter"></i>'.html_safe, "http://twitter.com/CodeMontage" %></li>
           <li class="social_media"><%= link_to '<i class="fi-social-facebook"></i>'.html_safe, "http://facebook.com/CodeMontage" %></li>
           <li class="social_media"><%= link_to '<i class="fi-social-tumblr"></i>'.html_safe, "http://codemontage.tumblr.com" %></li>
+          <li class="social_media"><%= link_to '<i class="fi-social-github"></i>'.html_safe, "http://github.com/CodeMontageHQ/codemontage" %></li>
           <li><%= link_to "Admin", admin_dashboard_path unless !user_signed_in? || !current_user.is_admin? %></li>
           <li><%= link_to "Dashboard", dashboard_path unless !user_signed_in? %></li>
           <li><%= link_to "Settings", edit_user_registration_path unless !user_signed_in? %></li>


### PR DESCRIPTION
Added the github icon in header. 
![github_link_in_header](https://f.cloud.github.com/assets/929753/2159045/e2ecf4c4-949d-11e3-8b10-88f8df3b7d70.png)

It will be nice if make them to open in new tab/page. Will do that in next commit.

Fixes #192 
## 

_Rajeswari_
_midnight foxes of [@spritle-dev-team](https://github.com/orgs/spritlesoftware/teams/spritle-dev-team)_
