### PR TITLE
Preload project tags in organization show

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -23,7 +23,7 @@ class OrganizationsController < ApplicationController
   def show
     @organization = Organization.find(params[:id])
     @jobs = @organization.jobs.active
-    @projects = @organization.projects.featured
+    @projects = @organization.projects.featured.includes :technologies, :causes
     @sponsorships = @organization.sponsorships
   end
 end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -65,25 +65,12 @@
               <div class="four columns">
                 <div id="project_causes">
                   <h5>Causes</h5>
-                  <% project.cause_list.each_with_index do |tag, index| %>
-                    <% if index == project.cause_list.length - 1 %>
-                      <%= link_to tag, projects_path(:tags => tag) %>
-                    <% else %>
-                      <%= link_to tag + ", ", projects_path(:tags => tag) %>
-                    <% end %>
-                  <% end %>
-                  
+                  <%= project_tags_link_list project, 'causes' %>
                 </div>
 
                 <div id="project_technologies">
                   <h5>Technologies</h5>
-                  <% project.technology_list.each_with_index do |tag, index| %>
-                    <% if index == project.technology_list.length - 1 %>
-                      <%= link_to tag, projects_path(:tags => tag) %>
-                    <% else %>
-                      <%= link_to tag + ", ", projects_path(:tags => tag) %>
-                    <% end %>
-                  <% end %>
+                  <%= project_tags_link_list project, 'technologies' %>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Used `project_tags_link_list` helper in organizations show page to display tags of projects and also preloaded the tags.

ref #186,  #187
