### PR TITLE
Fix Project#related_projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,7 +2,7 @@ class Project < ActiveRecord::Base
   belongs_to :organization
   acts_as_ordered_taggable
   acts_as_ordered_taggable_on :technologies, :causes
-  
+
   attr_accessible :organization_id, :name, :url, :github_repo, :description, :notes, :cause_list, :technology_list, :is_active, :is_approved
   validates_presence_of :name, :github_repo
 
@@ -15,7 +15,7 @@ class Project < ActiveRecord::Base
   scope :approved, where(:is_approved => true)
   scope :active, approved.where(:is_active => true)
   scope :featured, where("organization_id IS NOT NULL").active
-  scope :with_technologies_and_causes, includes(:technologies, :causes  )
+  scope :with_technologies_and_causes, includes(:technologies, :causes)
   scope :with_organization, includes(:organization)
 
   def github_display
@@ -24,14 +24,14 @@ class Project < ActiveRecord::Base
 
   def github_url
     "#{self.organization.github_url}/#{self.github_repo}"
-  end  
+  end
 
   def related_projects
-    self.organization.projects - [self]
+    self.organization.projects.where("id != ?", self.id)
   end
 
   def tasks_url
     "#{github_url}/issues"
-  end  
+  end
 
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -37,19 +37,15 @@ describe Project do
 
   describe "#related_projects" do
 
-    let(:project_1) { Project.new }
-    let(:project_2) { Project.new }
-    let(:project_3) { Project.new }
-
-    let(:organization) { Organization.new }
+    let(:organization) { Organization.create!(name: 'CodeMontage') }
 
     before do
-      project_1.stub(:organization) { organization }
-      organization.projects = [project_1, project_2, project_3]
+      @project_1 = Project.create!(name: 'Code Montage', organization_id: organization.id, github_repo: 'codemontage')
+      @project_2 = Project.create!(name: 'Happy Days', organization_id: organization.id, github_repo: 'happydays')
     end
 
     it "returns its organization's other projects" do
-      expect(project_1.related_projects).to eq([project_2, project_3])
+      expect(@project_1.related_projects).to eq([@project_2])
     end
 
   end


### PR DESCRIPTION
Fix for issue https://github.com/CodeMontageHQ/codemontage/issues/247

`#related_projects` should return an AR relation instead of an Array. Cannot chain the `featured` scope with an Array.

I have updated your specs to check the query.

cc @DBNess 
