### PR TITLE
Rails 4 Prep: Remove match routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ CodeMontage::Application.routes.draw do
   # User routes
   devise_for :users, :path => 'auth', :path_names => { :sign_in => 'login', :sign_out => 'logout'}, :controllers => { :registrations => 'registrations' }
   devise_scope :user do
-    get "settings" => "registrations#edit", :as => :edit_user_registration
     get "settings" => "registrations#edit", :as => :services
   end
   get '/dashboard', {:controller => 'home', :action => 'dashboard'}


### PR DESCRIPTION
#### ['match' is deprecated in Rails v4 routing](https://github.com/rails/rails/issues/5964), so let's clean up these instances as we prepare to upgrade

![cleanup](https://cloud.githubusercontent.com/assets/226228/4854705/b92f9f44-6097-11e4-9346-f225e031aba2.gif)
