### PR TITLE
events link lable changed from Devs For Good to NYC Meetup

### DIFF
--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -18,7 +18,7 @@
           <ul class="dropdown">
             <li><%= link_to "Women Coders Dinner", 'https://www.codemontage.com/events/amplify-women-coders-dinner' %></li>
             <li><%= link_to "Coder Day of Service", coder_day_path %></li>
-            <li><%= link_to "Devs For Good Meetup", "http://meetup.com/Developers-for-Good", :target => "_blank" %></li>
+            <li><%= link_to "NYC Meetup", "http://meetup.com/Developers-for-Good", :target => "_blank" %></li>
             <li><%= link_to "WriteSpeakCode Conf", "http://writespeakcode.com", :target => "_blank" %></li>
           </ul>
         </li>


### PR DESCRIPTION
fixes #266  
Changed label from 'Devs for Good' to 'NYC Meetup'

Before:
![before](https://cloud.githubusercontent.com/assets/7460686/4904752/f6bf85da-6449-11e4-93bc-d0a97791d082.png)

After:
![after](https://cloud.githubusercontent.com/assets/7460686/4904757/fd3f660a-6449-11e4-9ccf-ea05c939e02c.png)
