### PR TITLE
Backend additions (db, models) to allow featured projects for events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ActiveRecord::Base
   has_many :sponsors, through: :sponsorships, source: :organization
   has_many :sponsorships
   has_many :users, through: :event_registrations
+  has_many :featured_projects
+  has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -1,0 +1,4 @@
+class FeaturedProject < ActiveRecord::Base
+  belongs_to :project
+  belongs_to :event
+end

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -1,4 +1,6 @@
 class FeaturedProject < ActiveRecord::Base
   belongs_to :project
   belongs_to :event
+
+  validates_uniqueness_of :project_id, scope: :event_id
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,8 @@ class Project < ActiveRecord::Base
 
   has_many :favorite_projects
   has_many :users, through: :favorite_projects
+  has_many :featured_projects
+  has_many :events, through: :featured_projects
 
   include FriendlyId
   friendly_id :name, use: :slugged

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,8 +1,8 @@
 class CreateFeaturedProjects < ActiveRecord::Migration
   def change
     create_table :featured_projects do |t|
-      t.references :project, :null => false
-      t.references :event, :null => false
+      t.references :project, null: false
+      t.references :event, null: false
 
       t.timestamps
     end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,0 +1,12 @@
+class CreateFeaturedProjects < ActiveRecord::Migration
+  def change
+    create_table :featured_projects do |t|
+      t.references :project, :null => false
+      t.references :event, :null => false
+
+      t.timestamps
+    end
+
+    add_index :featured_projects, :event_id
+  end
+end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -8,5 +8,6 @@ class CreateFeaturedProjects < ActiveRecord::Migration
     end
 
     add_index :featured_projects, :event_id
+    add_index :featured_projects, :project_id
   end
 end

--- a/db/migrate/20150108141354_add_unique_index_to_featured_projects.rb
+++ b/db/migrate/20150108141354_add_unique_index_to_featured_projects.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFeaturedProjects < ActiveRecord::Migration
+  def change
+    add_index :featured_projects, [:project_id, :event_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(:version => 20150105164219) do
   end
 
   add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
+  add_index "featured_projects", ["project_id"], :name => "index_featured_projects_on_project_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150105164219) do
+ActiveRecord::Schema.define(:version => 20150108141354) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(:version => 20150105164219) do
   end
 
   add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
+  add_index "featured_projects", ["project_id", "event_id"], :name => "index_featured_projects_on_project_id_and_event_id", :unique => true
   add_index "featured_projects", ["project_id"], :name => "index_featured_projects_on_project_id"
 
   create_table "jobs", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140927013645) do
+ActiveRecord::Schema.define(:version => 20150105164219) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -77,6 +77,15 @@ ActiveRecord::Schema.define(:version => 20140927013645) do
 
   add_index "favorite_projects", ["project_id"], :name => "index_favorite_projects_on_project_id"
   add_index "favorite_projects", ["user_id"], :name => "index_favorite_projects_on_user_id"
+
+  create_table "featured_projects", :force => true do |t|
+    t.integer  "project_id", :null => false
+    t.integer  "event_id",   :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false


### PR DESCRIPTION
This PR allows event-specific featured projects to exist in the app. Purely backend work here:
* new FeaturedProject model
* new featured_projects table
* associations between events and projects, through featured_projects

Check it out in a console near you!
```ruby
> event = Event.create(name: "Test Event", short_code: "fake")
> project = Project.last
> fp = FeaturedProject.new
> fp.event = event
> fp.project = project
> fp.save
```

Future improvements:
- [ ] Add featured projects to automated event page
- [ ] Allow administrators to set featured projects on events