### PR TITLE
Allow admins to create featured projects

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -44,6 +44,13 @@ ActiveAdmin.register Event do
       f.input :eventbrite_url
       f.input :notes
     end
+
+    f.inputs 'Featured Projects' do
+      f.has_many :featured_projects, sortable: :project do |fp|
+        fp.input :project
+      end
+    end
+
     f.buttons
   end
 

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -45,7 +45,7 @@ ActiveAdmin.register Event do
       f.input :notes
     end
 
-    f.inputs 'Featured Projects' do
+    f.inputs "Featured Projects" do
       f.has_many :featured_projects, sortable: :project do |fp|
         fp.input :project
       end
@@ -87,13 +87,16 @@ ActiveAdmin.register Event do
     active_admin_comments
   end
 
-  sidebar 'Featured Projects', only: :show do
+  sidebar "Featured Projects", only: :show do
     table_for event.featured_projects do
       column :project
-      column 'Actions' do |fp|
-        link_to('View', admin_featured_project_path(fp), { class: 'member_link' }) +
-        link_to('Edit', edit_admin_featured_project_path(fp), { class: 'member_link' }) +
-        link_to('Delete', admin_featured_project_path(fp), { method: :delete, class: 'member_link' })
+      column "Actions" do |fp|
+        link_to("View", admin_featured_project_path(fp),
+          class: "member_link") +
+        link_to("Edit", edit_admin_featured_project_path(fp),
+          class: "member_link") +
+        link_to("Delete", admin_featured_project_path(fp),
+          method: :delete, class: "member_link")
       end
     end
   end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -90,6 +90,11 @@ ActiveAdmin.register Event do
   sidebar 'Featured Projects', only: :show do
     table_for event.featured_projects do
       column :project
+      column 'Actions' do |fp|
+        link_to('View', admin_featured_project_path(fp), { class: 'member_link' }) +
+        link_to('Edit', edit_admin_featured_project_path(fp), { class: 'member_link' }) +
+        link_to('Delete', admin_featured_project_path(fp), { method: :delete, class: 'member_link' })
+      end
     end
   end
 end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -86,4 +86,10 @@ ActiveAdmin.register Event do
     end
     active_admin_comments
   end
+
+  sidebar 'Featured Projects', only: :show do
+    table_for event.featured_projects do
+      column :project
+    end
+  end
 end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -92,11 +92,11 @@ ActiveAdmin.register Event do
       column :project
       column "Actions" do |fp|
         link_to("View", admin_featured_project_path(fp),
-          class: "member_link") +
+                class: "member_link") +
         link_to("Edit", edit_admin_featured_project_path(fp),
-          class: "member_link") +
+                class: "member_link") +
         link_to("Delete", admin_featured_project_path(fp),
-          method: :delete, class: "member_link")
+                method: :delete, class: "member_link")
       end
     end
   end

--- a/app/admin/featured_projects.rb
+++ b/app/admin/featured_projects.rb
@@ -1,0 +1,12 @@
+ActiveAdmin.register FeaturedProject do
+  menu parent: 'Events'
+
+  index do
+    column :id
+    column :event
+    column :project
+    column :created_at
+    column :updated_at
+    actions
+  end
+end

--- a/app/admin/featured_projects.rb
+++ b/app/admin/featured_projects.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register FeaturedProject do
-  menu parent: 'Events'
+  menu parent: "Events"
 
   index do
     column :id

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ActiveRecord::Base
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location
   attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
+  attr_accessible :featured_projects_attributes
   attr_writer :logo_delete
 
   # Paperclip
@@ -16,6 +17,8 @@ class Event < ActiveRecord::Base
                            url: '/system/images/logos/:class/:style/:id_:basename.:extension'
   validates_attachment_size :logo, less_than: 5.megabytes
   validates_attachment_content_type :logo, content_type: ['image/jpeg', 'image/png', 'image/gif']
+
+  accepts_nested_attributes_for :featured_projects
 
   include FriendlyId
   friendly_id :name, use: :slugged

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ActiveRecord::Base
   has_many :sponsors, through: :sponsorships, source: :organization
   has_many :sponsorships
   has_many :users, through: :event_registrations
+  has_many :featured_projects
+  has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -1,0 +1,4 @@
+class FeaturedProject < ActiveRecord::Base
+  belongs_to :project
+  belongs_to :event
+end

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -1,4 +1,6 @@
 class FeaturedProject < ActiveRecord::Base
   belongs_to :project
   belongs_to :event
+
+  attr_accessible :project_id, :event_id
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,8 @@ class Project < ActiveRecord::Base
 
   has_many :favorite_projects
   has_many :users, through: :favorite_projects
+  has_many :featured_projects
+  has_many :events, through: :featured_projects
 
   include FriendlyId
   friendly_id :name, use: :slugged

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,8 +1,8 @@
 class CreateFeaturedProjects < ActiveRecord::Migration
   def change
     create_table :featured_projects do |t|
-      t.references :project, :null => false
-      t.references :event, :null => false
+      t.references :project, null: false
+      t.references :event, null: false
 
       t.timestamps
     end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,0 +1,12 @@
+class CreateFeaturedProjects < ActiveRecord::Migration
+  def change
+    create_table :featured_projects do |t|
+      t.references :project, :null => false
+      t.references :event, :null => false
+
+      t.timestamps
+    end
+
+    add_index :featured_projects, :event_id
+  end
+end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -8,5 +8,6 @@ class CreateFeaturedProjects < ActiveRecord::Migration
     end
 
     add_index :featured_projects, :event_id
+    add_index :featured_projects, :project_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(:version => 20150105164219) do
   end
 
   add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
+  add_index "featured_projects", ["project_id"], :name => "index_featured_projects_on_project_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140927013645) do
+ActiveRecord::Schema.define(:version => 20150105164219) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -77,6 +77,15 @@ ActiveRecord::Schema.define(:version => 20140927013645) do
 
   add_index "favorite_projects", ["project_id"], :name => "index_favorite_projects_on_project_id"
   add_index "favorite_projects", ["user_id"], :name => "index_favorite_projects_on_user_id"
+
+  create_table "featured_projects", :force => true do |t|
+    t.integer  "project_id", :null => false
+    t.integer  "event_id",   :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false


### PR DESCRIPTION
Building on #291, this PR:
- allows mass assignment of FeaturedProject attributes
- allows events to take nested featured projects attributes
- adds featured projects to admin area
- allows featured projects to be added or edited directly from an event area

:point_down: :point_down: Photographic evidence below! :point_down: :point_down:

*Featured Projects in the Admin Menu*
![screenshot 2015-01-06 18 44 18](https://cloud.githubusercontent.com/assets/2766324/5638488/41b146d4-95d5-11e4-8a4f-6ede257d879d.png)

*Featured Projects index page*
![screenshot 2015-01-06 18 45 13](https://cloud.githubusercontent.com/assets/2766324/5638491/41c082e8-95d5-11e4-8a23-bb6cc23ff57e.png)

*Featured Projects new page*
![screenshot 2015-01-06 18 56 56](https://cloud.githubusercontent.com/assets/2766324/5638539/e1c4d55a-95d5-11e4-9751-d56f8369a845.png)

*Featured Projects sidebar in the Events show page*
![screenshot 2015-01-06 18 44 54](https://cloud.githubusercontent.com/assets/2766324/5638489/41b9fd2e-95d5-11e4-81b2-f0e817039dcb.png)

*Featured Projects nested inputs in the Events edit page*
![screenshot 2015-01-06 18 45 52](https://cloud.githubusercontent.com/assets/2766324/5638490/41bd9c40-95d5-11e4-8c73-a2d1f48d34d1.png)