### PR TITLE
Show an event's featured projects

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -1,0 +1,5 @@
+@import 'colors';
+
+#event_featured_projects {
+  padding: 3.5% 0;
+}

--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -15,3 +15,15 @@ h5 span.favorite {
     padding: 4px;
   }
 }
+
+.project-box {
+  border: solid 1px $cmDarkTeal;
+  border-radius: 3px;
+  margin-right: 15px;
+  margin-bottom: 15px;
+
+  &:last {
+    margin-right: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,5 +15,6 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @featured_projects = @event.projects
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ActiveRecord::Base
   has_many :sponsors, through: :sponsorships, source: :organization
   has_many :sponsorships
   has_many :users, through: :event_registrations
+  has_many :featured_projects
+  has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -1,0 +1,4 @@
+class FeaturedProject < ActiveRecord::Base
+  belongs_to :project
+  belongs_to :event
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,8 @@ class Project < ActiveRecord::Base
 
   has_many :favorite_projects
   has_many :users, through: :favorite_projects
+  has_many :featured_projects
+  has_many :events, through: :featured_projects
 
   include FriendlyId
   friendly_id :name, use: :slugged

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,13 +17,9 @@
 
     <% if @featured_projects %>
       <div id="event_featured_projects" class="row">
-        <div class="">
-          <ul>
-            <% @featured_projects.each do |featured_project| %>
-              <li><%= link_to(featured_project.name, project_path(featured_project)) %></li>
-            <% end %>
-          </ul>
-        </div>
+        <% @featured_projects.each do |featured_project| %>
+          <%= render partial: 'projects/project_box', locals: { project: featured_project } %>
+        <% end %>
       </div>
     <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,11 +16,11 @@
     </div>
 
     <% if @featured_projects %>
-      <div id="event_featured_projects" class="row">
+      <ul id="event_featured_projects"class="large-block-grid-3 medium-block-grid-1">
         <% @featured_projects.each do |featured_project| %>
           <%= render partial: 'projects/project_box', locals: { project: featured_project } %>
         <% end %>
-      </div>
+      </ul>
     <% end %>
 
     <div id="event_rsvp" class="row">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,6 @@
 <body>
   <% content_for :title do @event.name end %>
+
   <div class="event">
     <div id="event_welcome" class="row">
       <div class="large-8 columns large-centered">
@@ -13,6 +14,7 @@
         <p><%=raw @event.description %><p>
       </div>
     </div>
+
     <div id="event_rsvp" class="row">
       <div class="large-6 columns large-centered text-center">
         <%= %>
@@ -23,26 +25,29 @@
         <% end %>
       </div>
     </div>
+
     <% if @event.sponsors.present? %>
-    <div id="event_sponsors" class="row">
-      <div class="large-10 columns large-centered">
-        <h2><%= @event.name %> Sponsors</h2>
-        <div class="sponsors row large-centered">
-          <% @event.sponsors.each do |featured| %>
-            <div class="large-4 columns">
-                <h5>
-                <% if find_logo?(featured) %>
-                  <%= link_to (image_tag find_logo(featured)), organization_path(featured) %>
-                <% else %>
-                  <%= link_to featured.name, organization_path(featured) %>
-                <% end %>
-                </h5>
-            </div>
-          <% end %>
+      <div id="event_sponsors" class="row">
+        <div class="large-10 columns large-centered">
+          <h2><%= @event.name %> Sponsors</h2>
+          <div class="sponsors row large-centered">
+            <% @event.sponsors.each do |featured| %>
+              <div class="large-4 columns">
+                  <h5>
+                  <% if find_logo?(featured) %>
+                    <%= link_to (image_tag find_logo(featured)), organization_path(featured) %>
+                  <% else %>
+                    <%= link_to featured.name, organization_path(featured) %>
+                  <% end %>
+                  </h5>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
     <% end %>
   </div>
+
   <% content_for(:press) do %>Press<% end %>
+
 </body>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,7 @@
         <%= image_tag @event.logo, :alt => @event.name %>
       </div>
       <div>
-        </br>
-        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></br>
-        </p>
+        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
       </div>
       <div class="large-8 columns large-centered">
         <h1><%= @event.name %></h1>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -15,6 +15,18 @@
       </div>
     </div>
 
+    <% if @featured_projects %>
+      <div id="event_featured_projects" class="row">
+        <div class="">
+          <ul>
+            <% @featured_projects.each do |featured_project| %>
+              <li><%= link_to(featured_project.name, project_path(featured_project)) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
     <div id="event_rsvp" class="row">
       <div class="large-6 columns large-centered text-center">
         <%= %>

--- a/app/views/projects/_project_box.html.erb
+++ b/app/views/projects/_project_box.html.erb
@@ -1,0 +1,36 @@
+<div class="project_box large-4 columns">
+
+  <h5><%= link_to project.name, project_path(project) %>
+    <span class="favorite">
+      <% if user_signed_in? %>
+        <% if current_user.favorite_projects.include?(project.id) %>
+          <%= link_to '<i class="fi-star"></i> '.html_safe, dashboard_path, :class => "favorited" %>
+        <% else %>
+          <%= button_to "Save", favorites_path(:project_id => project.id), :remote => true, :class => "favorite tiny radius button" %>
+        <% end %>
+      <% else %>
+        <%= link_to '<i class="fi-star"></i> '.html_safe + "Save", new_user_session_path, :target => '_blank' %>
+      <% end %>
+    </span>
+  </h5>
+
+  <div class="project_links">
+    <ul class="no-bullet inline-list">
+      <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' unless !project.github_url.present? %></li>
+      <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' unless !project.tasks_url.present? %></li>
+      <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + "News", twitter_url(project.organization.twitter), :target => '_blank' unless !project.organization.twitter.present? %></li>
+    </ul>
+  </div>
+
+  <div class="row">
+    <div class="project_technologies large-6 columns">
+      <h6>Technologies</h6>
+      <%= project_tags_link_list project, 'technologies' %>
+    </div>
+
+    <div class="project_causes large-6 columns">
+      <h6>Causes</h6>
+      <%= project_tags_link_list project, 'causes' %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/_project_box.html.erb
+++ b/app/views/projects/_project_box.html.erb
@@ -1,5 +1,4 @@
-<div class="project_box large-4 columns">
-
+<li class="project-box">
   <h5><%= link_to project.name, project_path(project) %>
     <span class="favorite">
       <% if user_signed_in? %>
@@ -33,4 +32,4 @@
       <%= project_tags_link_list project, 'causes' %>
     </div>
   </div>
-</div>
+</li>

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,8 +1,8 @@
 class CreateFeaturedProjects < ActiveRecord::Migration
   def change
     create_table :featured_projects do |t|
-      t.references :project, :null => false
-      t.references :event, :null => false
+      t.references :project, null: false
+      t.references :event, null: false
 
       t.timestamps
     end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -1,0 +1,12 @@
+class CreateFeaturedProjects < ActiveRecord::Migration
+  def change
+    create_table :featured_projects do |t|
+      t.references :project, :null => false
+      t.references :event, :null => false
+
+      t.timestamps
+    end
+
+    add_index :featured_projects, :event_id
+  end
+end

--- a/db/migrate/20150105164219_create_featured_projects.rb
+++ b/db/migrate/20150105164219_create_featured_projects.rb
@@ -8,5 +8,6 @@ class CreateFeaturedProjects < ActiveRecord::Migration
     end
 
     add_index :featured_projects, :event_id
+    add_index :featured_projects, :project_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(:version => 20150105164219) do
   end
 
   add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
+  add_index "featured_projects", ["project_id"], :name => "index_featured_projects_on_project_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140927013645) do
+ActiveRecord::Schema.define(:version => 20150105164219) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -77,6 +77,15 @@ ActiveRecord::Schema.define(:version => 20140927013645) do
 
   add_index "favorite_projects", ["project_id"], :name => "index_favorite_projects_on_project_id"
   add_index "favorite_projects", ["user_id"], :name => "index_favorite_projects_on_user_id"
+
+  create_table "featured_projects", :force => true do |t|
+    t.integer  "project_id", :null => false
+    t.integer  "event_id",   :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "featured_projects", ["event_id"], :name => "index_featured_projects_on_event_id"
 
   create_table "jobs", :force => true do |t|
     t.integer  "organization_id",               :null => false


### PR DESCRIPTION
- shows an event's featured projects on its page
- using a handy-dandy partial that can be used elsewhere on the site

Definitely not 100% on some of the choices I made here. The use of pixel-lengths in the CSS is a major red flag to me, and there is some size-related ugliness as the page gets smaller, the lengths of project names change, technologies/causes are or are not included, etc. etc. Also there's some strangeness around the current save button.

Clearly a lot of improvements can be made, but it's a start.

*Featuring projects, when everything is well-shaped and the page is big*
![screenshot 2015-01-07 22 56 19](https://cloud.githubusercontent.com/assets/2766324/5657694/9c77e046-96c0-11e4-9b5b-5ef9eae5e7ae.png)

*Featuring projects, when the page is big but shapes are different*
![screenshot 2015-01-07 22 56 02](https://cloud.githubusercontent.com/assets/2766324/5657695/9c7adeae-96c0-11e4-88c4-3b71e9498dba.png)

*Featuring projects, when the page is small*
![screenshot 2015-01-07 22 56 48](https://cloud.githubusercontent.com/assets/2766324/5657696/9c7b8de0-96c0-11e4-889b-af20f9ec66f0.png)