### PR TITLE
Projects index refactor (to use a partial)

### DIFF
--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -13,11 +13,11 @@
         <% end %>
       </span>
     </h5>
+
     <p><%= project.description %></p>
   </div>
 
   <div class="project_links large-2 columns">
-    </br>
     <ul class="no-bullet">
       <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' unless !project.github_url.present? %></li>
       <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' unless !project.tasks_url.present? %></li>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="project_summary large-6 columns">
+    <h5><%= link_to project.name, project_path(project) %>
+      <span class="favorite">
+        <% if user_signed_in? %>
+          <% if @favorite_projects.include?(project.id) %>
+            <%= link_to '<i class="fi-star"></i> '.html_safe, dashboard_path, :class => "favorited" %>
+          <% else %>
+            <%= button_to "Save", favorites_path(:project_id => project.id), :remote => true, :class => "favorite tiny radius button" %>
+          <% end %>
+        <% else %>
+          <%= link_to '<i class="fi-star"></i> '.html_safe + "Save", new_user_session_path, :target => '_blank' %>
+        <% end %>
+      </span>
+    </h5>
+    <p><%= project.description %></p>
+  </div>
+
+  <div class="project_links large-2 columns">
+    </br>
+    <ul class="no-bullet">
+      <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' unless !project.github_url.present? %></li>
+      <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' unless !project.tasks_url.present? %></li>
+      <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + "News", twitter_url(project.organization.twitter), :target => '_blank' unless !project.organization.twitter.present? %></li>
+    </ul>
+  </div>
+
+  <div class="project_technologies large-2 columns">
+    <h6>Technologies</h6>
+    <%= project_tags_link_list project, 'technologies' %>
+  </div>
+
+  <div class="project_causes large-2 columns">
+    <h6>Causes</h6>
+    <%= project_tags_link_list project, 'causes' %>
+  </div>
+</div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,12 +1,12 @@
 <div class="row">
-  <div>
-    <div class="projects">
-      <h4><%= params[:tags] + " " unless !params[:tags].present? %>Projects</h4>
+  <div class="projects">
+    <h4><%= params[:tags] + " " unless !params[:tags].present? %>Projects</h4>
 
-      <% if @featured_projects.present? %>
-        <p>These open source, community-driven projects are making the world better and could really use your help. Check them out and contribute however you'd like. Or, view <%= link_to "organizations", organizations_path %>.
-          Excited to contribute, but can't dig in right now? <%= link_to "Code Later", code_later_url %>!</p>
+    <% if @featured_projects.present? %>
+      <p>These open source, community-driven projects are making the world better and could really use your help. Check them out and contribute however you'd like. Or, view <%= link_to "organizations", organizations_path %>.
+        Excited to contribute, but can't dig in right now? <%= link_to "Code Later", code_later_url %>!</p>
 
+      <div class="row">
         <% @featured_projects.each do |project| %>
           <div class="row">
             <div class="project_summary large-6 columns">
@@ -47,15 +47,14 @@
 
           </div>
         <% end %>
-      <% else %>
-        <p>Oops! We can't seem to find any <%= params[:tags] %> projects. <%= link_to "View all projects", projects_path %>, or <%= link_to "view by organization", organizations_path %>.</p>
-      <% end %>
-    </div>
-    
-    <div class="resources">
-      <h6>Looking for something else?</h6>
-      <p>Check out our <%= link_to "resources", resources_path %> to connect with other ways to learn, code, and do good.</p>
-    </div>
+      </div>
+    <% else %>
+      <p>Oops! We can't seem to find any <%= params[:tags] %> projects. <%= link_to "View all projects", projects_path %>, or <%= link_to "view by organization", organizations_path %>.</p>
+    <% end %>
+  </div>
 
+  <div class="resources">
+    <h6>Looking for something else?</h6>
+    <p>Check out our <%= link_to "resources", resources_path %> to connect with other ways to learn, code, and do good.</p>
   </div>
 </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -8,44 +8,7 @@
 
       <div class="row">
         <% @featured_projects.each do |project| %>
-          <div class="row">
-            <div class="project_summary large-6 columns">
-              <h5><%= link_to project.name, project_path(project) %>
-                <span class="favorite">
-                  <% if user_signed_in? %>
-                    <% if @favorite_projects.include?(project.id) %>
-                      <%= link_to '<i class="fi-star"></i> '.html_safe, dashboard_path, :class => "favorited" %>
-                    <% else %>
-                      <%= button_to "Save", favorites_path(:project_id => project.id), :remote => true, :class => "favorite tiny radius button" %>
-                    <% end %>
-                  <% else %>
-                    <%= link_to '<i class="fi-star"></i> '.html_safe + "Save", new_user_session_path, :target => '_blank' %>
-                  <% end %>
-                </span>
-              </h5>
-              <p><%= project.description %></p>
-            </div>
-
-            <div class="project_links large-2 columns">
-              </br>
-              <ul class="no-bullet">
-                <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' unless !project.github_url.present? %></li>
-                <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' unless !project.tasks_url.present? %></li>
-                <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + "News", twitter_url(project.organization.twitter), :target => '_blank' unless !project.organization.twitter.present? %></li>
-              </ul>
-            </div>
-
-            <div class="project_technologies large-2 columns">
-              <h6>Technologies</h6>
-              <%= project_tags_link_list project, 'technologies' %>
-            </div>
-
-            <div class="project_causes large-2 columns">
-              <h6>Causes</h6>
-              <%= project_tags_link_list project, 'causes' %>
-            </div>
-
-          </div>
+          <%= render partial: 'project', locals: { project: project } %>
         <% end %>
       </div>
     <% else %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -6,11 +6,9 @@
       <p>These open source, community-driven projects are making the world better and could really use your help. Check them out and contribute however you'd like. Or, view <%= link_to "organizations", organizations_path %>.
         Excited to contribute, but can't dig in right now? <%= link_to "Code Later", code_later_url %>!</p>
 
-      <div class="row">
-        <% @featured_projects.each do |project| %>
-          <%= render partial: 'project', locals: { project: project } %>
-        <% end %>
-      </div>
+      <% @featured_projects.each do |project| %>
+        <%= render partial: 'project', locals: { project: project } %>
+      <% end %>
     <% else %>
       <p>Oops! We can't seem to find any <%= params[:tags] %> projects. <%= link_to "View all projects", projects_path %>, or <%= link_to "view by organization", organizations_path %>.</p>
     <% end %>


### PR DESCRIPTION
While we're partialling things all willy-nilly, here's a quick refactor of the projects index.

Here's a screenshot of it looking exactly the same:
![screenshot 2015-01-07 23 05 04](https://cloud.githubusercontent.com/assets/2766324/5657742/af61734c-96c1-11e4-9c06-c6d2696a8989.png)
