### PR TITLE
Change event "registrations" to "check ins" for users & admins

### DIFF
--- a/app/admin/event_registrations.rb
+++ b/app/admin/event_registrations.rb
@@ -1,4 +1,6 @@
-ActiveAdmin.register EventRegistration do
+ActiveAdmin.register EventRegistration, as: "Check In" do
+  menu parent: "Events"
+
   index do
     column 'Event', sortable: :event_name do |registration|
       link_to registration.event.name, admin_event_path(registration.event)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,7 +33,7 @@ APP = {
     dashboard: function() {
 			$("form.button_to")
 				.bind("ajax:beforeSend", function(e, xhr) {
-					$(e.target).parent("span.registration").html('<i class="fi-check"></i> Registered');
+					$(e.target).parent("span.check_in").html('<i class="fi-check"></i> Checked In');
 				});
     }
   },

--- a/app/views/home/dashboard/_events.html.erb
+++ b/app/views/home/dashboard/_events.html.erb
@@ -19,12 +19,12 @@
         </ul>
       </p>
     </div>
-    <div class="event_registration text-center">
-      <span class="registration">
+    <div class="event_check_in text-center">
+      <span class="check_in">
         <% if @registered_events.include?(event) %>
-          <p><i class="fi-check"></i> Registered<p>
+          <p><i class="fi-check"></i> Checked In<p>
         <% else %>
-        <%= button_to "Register", events_path(:short_code => event.short_code), :remote => :true, :class => "radius button" %>
+        <%= button_to "Check In", events_path(:short_code => event.short_code), :remote => :true, :class => "radius button" %>
         <% end %>
       </span>
     </div>

--- a/app/views/home/dashboard/_events.html.erb
+++ b/app/views/home/dashboard/_events.html.erb
@@ -1,5 +1,5 @@
 <div id="events" class="index radius panel row">
-  
+
   <div id="coder_day">
   <% if @upcoming_events.present? %>
     <h3>Upcoming Events</h3>
@@ -30,7 +30,7 @@
     </div>
     <% end %>
   <% else %>
-    <h3>Let's Chat</h3>  
+    <h3>Let's Chat</h3>
     <p>Working on something great? Share with us!
       <ul class="no-bullet">
         <li><%= link_to '<i class="fi-megaphone"></i> '.html_safe + " CodeMontage Chat", 'http://tlk.io/codemontage', :target => '_blank' %></li>


### PR DESCRIPTION
Front end change to introduce the concept of check-ins to users and admins. Clearly the ActiveAdmin error handling is still tied to the model name (as seen in the green notice in the screenshot below), but that should change when back end switches are made -- see #295.

*The administrative check-in experience*
![screenshot 2015-01-09 00 52 44](https://cloud.githubusercontent.com/assets/2766324/5676045/d7211560-979b-11e4-823c-b71a825d5721.png)

*Checking in(!) on the user dashboard*
![screenshot 2015-01-09 00 52 23](https://cloud.githubusercontent.com/assets/2766324/5676041/b915935c-979b-11e4-9c07-e0a78411508a.png)
