### PR TITLE
Add simple unit specs for featured_projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'client_side_validations-simple_form'
 group :development, :test do
   gem 'rspec-rails'
   gem 'capybara'
+  gem 'factory_girl_rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,11 @@ GEM
     erubis (2.7.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     faraday (0.8.7)
       multipart-post (~> 1.1)
     fastercsv (1.5.5)
@@ -259,6 +264,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   compass-rails
   devise (~> 3.3.0)
+  factory_girl_rails
   friendly_id (~> 4.0.10)
   geocoder
   jquery-rails

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :event do
+    short_code "CodeCarnival2015x1"
+    name "Code Carnival"
+    start_date { Time.now + 1.day }
+    end_date { Time.now + 1.day + 6.hours }
+  end
+end

--- a/spec/factories/featured_projects.rb
+++ b/spec/factories/featured_projects.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :featured_project do
+    association :event
+    association :project
+  end
+end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :organization do
+    name "CodeMontage"
+    github_org "CodeMontageHQ"
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :project do
+    association :organization
+    name "CodeMontage"
+    github_repo "codemontage"
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Event do
   it { should have_many(:featured_projects) }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe Event do
+  it { should have_many(:featured_projects) }
+  it { should have_many(:projects).through(:featured_projects) }
+end

--- a/spec/models/featured_project_spec.rb
+++ b/spec/models/featured_project_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe FeaturedProject do
   it { should belong_to(:event) }

--- a/spec/models/featured_project_spec.rb
+++ b/spec/models/featured_project_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe FeaturedProject do
+  it { should belong_to(:event) }
+  it { should belong_to(:project) }
+
+  it { should validate_uniqueness_of(:project_id).scoped_to(:event_id) }
+
+  it { should allow_mass_assignment_of(:project_id) }
+  it { should allow_mass_assignment_of(:event_id) }
+end

--- a/spec/models/featured_project_spec.rb
+++ b/spec/models/featured_project_spec.rb
@@ -4,7 +4,10 @@ describe FeaturedProject do
   it { should belong_to(:event) }
   it { should belong_to(:project) }
 
-  it { should validate_uniqueness_of(:project_id).scoped_to(:event_id) }
+  describe "validations" do
+    subject { create(:featured_project) }
+    it { should validate_uniqueness_of(:project_id).scoped_to(:event_id) }
+  end
 
   it { should allow_mass_assignment_of(:project_id) }
   it { should allow_mass_assignment_of(:event_id) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Project do
   it { should belong_to(:organization) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 describe Project do
   it { should belong_to(:organization) }
+  it { should have_many(:featured_projects) }
+  it { should have_many(:events).through(:featured_projects) }
+
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:github_repo) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,10 @@ RSpec.configure do |config|
   # config.mock_with :rr
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # Include Factory Girl syntax to simplify calls to factories
+  config.include FactoryGirl::Syntax::Methods
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
- Includes handful of specs meant to be a starting place for testing featured projects
- Adds factory_girl_rails to make testing a join model (like `FeaturedProject`) easier
- Includes (very minimal) factories for all `FeaturedProject`-relevant models: `Event`, `Organization`, & `Project`

Factory_girl_rails was especially necessary because the shoulda-matchers `#validates_uniqueness_of` method requires an instance of the model to exist in the database.

*suite still passes*
![screenshot 2015-01-09 08 45 34](https://cloud.githubusercontent.com/assets/2766324/5680548/97629642-97dc-11e4-9e60-fcf9d1230010.png)