### PR TITLE
Add featured projects to events show page

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -1,0 +1,5 @@
+@import 'colors';
+
+#event_featured_projects {
+  margin-bottom: 4%;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,5 +15,6 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @featured_projects = @event.projects
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,11 +6,6 @@ class ProjectsController < ApplicationController
       else
         Project.featured
       end.with_technologies_and_causes.with_organization
-
-    @favorite_projects =
-      if current_user.present?
-        FavoriteProject.where(user_id: current_user.id).map(&:project_id).to_set
-      end
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,10 @@ class User < ActiveRecord::Base
     services.where(provider: 'github').exists?
   end
 
+  def favorited_projects
+    favorite_projects.map(&:project_id).to_set
+  end
+
   protected
 
   def create_profile

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,5 +1,6 @@
 <body>
   <% content_for :title do @event.name end %>
+
   <div class="event">
     <div id="event_welcome" class="row">
       <div class="large-8 columns large-centered">
@@ -13,6 +14,7 @@
         <p><%=raw @event.description %><p>
       </div>
     </div>
+
     <div id="event_rsvp" class="row">
       <div class="large-6 columns large-centered text-center">
         <%= %>
@@ -23,26 +25,29 @@
         <% end %>
       </div>
     </div>
+
     <% if @event.sponsors.present? %>
-    <div id="event_sponsors" class="row">
-      <div class="large-10 columns large-centered">
-        <h2><%= @event.name %> Sponsors</h2>
-        <div class="sponsors row large-centered">
-          <% @event.sponsors.each do |featured| %>
-            <div class="large-4 columns">
-                <h5>
-                <% if find_logo?(featured) %>
-                  <%= link_to (image_tag find_logo(featured)), organization_path(featured) %>
-                <% else %>
-                  <%= link_to featured.name, organization_path(featured) %>
-                <% end %>
-                </h5>
-            </div>
-          <% end %>
+      <div id="event_sponsors" class="row">
+        <div class="large-10 columns large-centered">
+          <h2><%= @event.name %> Sponsors</h2>
+          <div class="sponsors row large-centered">
+            <% @event.sponsors.each do |featured| %>
+              <div class="large-4 columns">
+                  <h5>
+                  <% if find_logo?(featured) %>
+                    <%= link_to (image_tag find_logo(featured)), organization_path(featured) %>
+                  <% else %>
+                    <%= link_to featured.name, organization_path(featured) %>
+                  <% end %>
+                  </h5>
+              </div>
+            <% end %>
+          </div>
         </div>
       </div>
-    </div>
     <% end %>
   </div>
+
   <% content_for(:press) do %>Press<% end %>
+
 </body>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,7 @@
         <%= image_tag @event.logo, :alt => @event.name %>
       </div>
       <div>
-        </br>
-        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></br>
-        </p>
+        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
       </div>
       <div class="large-8 columns large-centered">
         <h1><%= @event.name %></h1>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,7 +16,8 @@
       </div>
 
       <div id="event_featured_projects" class="large-8 columns large-centered">
-        <% if @featured_projects %>
+        <% if @featured_projects.present? %>
+          <h4>Featured Projects</h4>
           <%= render partial: 'projects/project', collection: @featured_projects %>
         <% end %>
       </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,23 +9,18 @@
       <div>
         <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
       </div>
+
       <div class="large-8 columns large-centered">
         <h1><%= @event.name %></h1>
         <p><%=raw @event.description %><p>
       </div>
-    </div>
 
-    <% if @featured_projects %>
-      <div id="event_featured_projects" class="row">
-        <div class="">
-          <ul>
-            <% @featured_projects.each do |featured_project| %>
-              <li><%= link_to(featured_project.name, project_path(featured_project)) %></li>
-            <% end %>
-          </ul>
-        </div>
+      <div id="event_featured_projects" class="large-8 columns large-centered">
+        <% if @featured_projects %>
+          <%= render partial: 'projects/project', collection: @featured_projects %>
+        <% end %>
       </div>
-    <% end %>
+    </div>
 
     <div id="event_rsvp" class="row">
       <div class="large-6 columns large-centered text-center">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -15,6 +15,18 @@
       </div>
     </div>
 
+    <% if @featured_projects %>
+      <div id="event_featured_projects" class="row">
+        <div class="">
+          <ul>
+            <% @featured_projects.each do |featured_project| %>
+              <li><%= link_to(featured_project.name, project_path(featured_project)) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
     <div id="event_rsvp" class="row">
       <div class="large-6 columns large-centered text-center">
         <%= %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -3,7 +3,7 @@
     <h5><%= link_to project.name, project_path(project) %>
       <span class="favorite">
         <% if user_signed_in? %>
-          <% if @favorite_projects.include?(project.id) %>
+          <% if current_user.favorited_projects.include?(project.id) %>
             <%= link_to '<i class="fi-star"></i> '.html_safe, dashboard_path, :class => "favorited" %>
           <% else %>
             <%= button_to "Save", favorites_path(:project_id => project.id), :remote => true, :class => "favorite tiny radius button" %>


### PR DESCRIPTION
Uses the existing project partial to show featured projects on an individual events show page

This required refactoring the `@favorite_projects` instance variable from `UsersController` to `User#favorited_projects`.

*Featured projects sitting pretty on events show page*
![screenshot 2015-01-09 09 50 30](https://cloud.githubusercontent.com/assets/2766324/5682339/3fc444e2-97ed-11e4-9581-4a44479575cd.png)
