### PR TITLE
Add public flag to events

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -77,6 +77,7 @@ ActiveAdmin.register Event do
           'No image available'
         end
       end
+      row "Public?" do ad.is_public end
       row :chat_url do link_to ad.chat_url, ad.chat_url if ad.chat_url.present? end
       row :map_url do link_to ad.map_url, ad.map_url if ad.map_url.present? end
       row :schedule_url do link_to ad.schedule_url, ad.schedule_url if ad.schedule_url.present? end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Event do
     column :organizer
     column :organizer_email
     column :location
-    column 'Public?', :is_public
+    column "Public?", :is_public
     default_actions
   end
 
@@ -38,7 +38,7 @@ ActiveAdmin.register Event do
       else
         f.input :logo, as: :file
       end
-      f.input :is_public, label: 'Public?'
+      f.input :is_public, label: "Public?"
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -15,6 +15,7 @@ ActiveAdmin.register Event do
     column :organizer
     column :organizer_email
     column :location
+    column 'Public?', :is_public
     default_actions
   end
 
@@ -37,6 +38,7 @@ ActiveAdmin.register Event do
       else
         f.input :logo, as: :file
       end
+      f.input :is_public, label: 'Public?'
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register Event do
       else
         f.input :logo, as: :file
       end
-      f.input :is_public, label: "Public?"
+      f.input :is_public, label: "Public?", as: :boolean
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,8 +7,9 @@ class Event < ActiveRecord::Base
   has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
-  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location
-  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url, :is_public
+  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email
+  attr_accessible :organizer, :organizer_email, :location, :is_public
+  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
   attr_accessible :featured_projects_attributes
   attr_writer :logo_delete
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,7 @@ class Event < ActiveRecord::Base
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location
-  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
+  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url, :is_public
   attr_accessible :featured_projects_attributes
   attr_writer :logo_delete
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,6 +24,7 @@ class Event < ActiveRecord::Base
   friendly_id :name, use: :slugged
 
   scope :upcoming_events, where('end_date >= ?', Date.tomorrow)
+  scope :public_events, -> { where(is_public: true) }
 
   def self.featured
     upcoming_events.order('start_date').first

--- a/db/migrate/20150112145730_add_is_public_to_events.rb
+++ b/db/migrate/20150112145730_add_is_public_to_events.rb
@@ -1,0 +1,5 @@
+class AddIsPublicToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :is_public, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150108141354) do
+ActiveRecord::Schema.define(:version => 20150112145730) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(:version => 20150108141354) do
     t.string   "organizer"
     t.string   "organizer_email"
     t.string   "location"
+    t.boolean  "is_public",         :default => false, :null => false
   end
 
   add_index "events", ["short_code"], :name => "index_events_on_short_code", :unique => true


### PR DESCRIPTION
This adds a lil bitty boolean on events to say whether they're public (and thus share-ready) or not. Includes:
- necessary db migration/model changes
- form additions to the admin area
- scope for future frontend/controller changes

*Admin can see public status*
![screenshot 2015-01-12 10 28 29](https://cloud.githubusercontent.com/assets/2766324/5705247/d18bcf08-9a45-11e4-8a80-cdaf454fb6f4.png)

*Admin can change public status*
![screenshot 2015-01-12 10 28 40](https://cloud.githubusercontent.com/assets/2766324/5705251/d872ce0c-9a45-11e4-9ac4-fdecb2e31891.png)