### PR TITLE
Only show public events on the events index page

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register Event do
     column :organizer
     column :organizer_email
     column :location
-    column 'Public?', :is_public
+    column "Public?", :is_public
     default_actions
   end
 
@@ -38,7 +38,7 @@ ActiveAdmin.register Event do
       else
         f.input :logo, as: :file
       end
-      f.input :is_public, label: 'Public?'
+      f.input :is_public, label: "Public?"
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -15,6 +15,7 @@ ActiveAdmin.register Event do
     column :organizer
     column :organizer_email
     column :location
+    column 'Public?', :is_public
     default_actions
   end
 
@@ -37,6 +38,7 @@ ActiveAdmin.register Event do
       else
         f.input :logo, as: :file
       end
+      f.input :is_public, label: 'Public?'
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,7 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.order('start_date desc')
+    @events = Event.public_events.order('start_date desc')
   end
 
   def show

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,7 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.public_events.order('start_date desc')
+    @events = Event.public_events.order("start_date desc")
   end
 
   def show

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,8 +7,9 @@ class Event < ActiveRecord::Base
   has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
-  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location
-  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url, :is_public
+  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email
+  attr_accessible :organizer, :organizer_email, :location, :is_public
+  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
   attr_accessible :featured_projects_attributes
   attr_writer :logo_delete
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,7 @@ class Event < ActiveRecord::Base
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
   attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :organizer, :organizer_email, :location
-  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
+  attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url, :is_public
   attr_accessible :featured_projects_attributes
   attr_writer :logo_delete
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,6 +24,7 @@ class Event < ActiveRecord::Base
   friendly_id :name, use: :slugged
 
   scope :upcoming_events, where('end_date >= ?', Date.tomorrow)
+  scope :public_events, -> { where(is_public: true) }
 
   def self.featured
     upcoming_events.order('start_date').first

--- a/db/migrate/20150112145730_add_is_public_to_events.rb
+++ b/db/migrate/20150112145730_add_is_public_to_events.rb
@@ -1,0 +1,5 @@
+class AddIsPublicToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :is_public, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150108141354) do
+ActiveRecord::Schema.define(:version => 20150112145730) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(:version => 20150108141354) do
     t.string   "organizer"
     t.string   "organizer_email"
     t.string   "location"
+    t.boolean  "is_public",         :default => false, :null => false
   end
 
   add_index "events", ["short_code"], :name => "index_events_on_short_code", :unique => true


### PR DESCRIPTION
Teensy change that shows only events flagged public on the events index page.

*Three events on the events index*
![screenshot 2015-01-15 20 32 46](https://cloud.githubusercontent.com/assets/2766324/5770349/1efc0574-9cf7-11e4-8656-24d3283fb55b.png)

*But five in the database! And look which ones are marked public!*
![screenshot 2015-01-15 20 32 55](https://cloud.githubusercontent.com/assets/2766324/5770356/3380879a-9cf7-11e4-8943-d8ea8965497f.png)

