### PR TITLE
Create prompt for check ins

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,7 +37,8 @@ APP = {
     dashboard: function() {
 			$("form.button_to")
 				.bind("ajax:beforeSend", function(e, xhr) {
-					$(e.target).parent("span.check_in").html('<i class="fi-check"></i> Checked In');
+					$(e.target).parent("span.check_in")
+            .html('<i class="fi-check"></i> Checked In');
 				});
     }
   },

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,10 @@ APP = {
     init: function() {
 			// $(document).foundationTopBar();
 			// $(document).foundationTopBar();
+      $("a.check-in")
+        .bind("ajax:beforeSend", function(e, xhr) {
+          $(e.target).parent("span.check_in").html('<i class="fi-check"></i> Checked In');
+        });
     }
   },
   home: {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,8 @@ APP = {
 			// $(document).foundationTopBar();
       $("a.check-in")
         .bind("ajax:beforeSend", function(e, xhr) {
-          $(e.target).parent("span.check_in").html('<i class="fi-check"></i> Checked In');
+          $(e.target).parent("span.check_in")
+            .html("<i class=\"fi-check\"></i> Checked In");
         });
     }
   },
@@ -38,7 +39,7 @@ APP = {
 			$("form.button_to")
 				.bind("ajax:beforeSend", function(e, xhr) {
 					$(e.target).parent("span.check_in")
-            .html('<i class="fi-check"></i> Checked In');
+            .html("<i class=\"fi-check\"></i> Checked In");
 				});
     }
   },

--- a/app/assets/javascripts/check_in_prompt.js
+++ b/app/assets/javascripts/check_in_prompt.js
@@ -1,0 +1,7 @@
+$(document).ready( function() {
+
+  if ($("#check_in_prompt")[0]) {
+    $('#check_in_prompt').foundation('reveal', 'open')
+  }
+
+});

--- a/app/assets/javascripts/check_in_prompt.js
+++ b/app/assets/javascripts/check_in_prompt.js
@@ -1,7 +1,7 @@
 $(document).ready( function() {
 
   if ($("#check_in_prompt")[0]) {
-    $('#check_in_prompt').foundation('reveal', 'open')
+    $("#check_in_prompt").foundation("reveal", "open");
   }
 
 });

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -3,3 +3,7 @@
 #event_featured_projects {
   margin-bottom: 4%;
 }
+
+.check-in {
+  margin-top:25px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,4 +32,10 @@ class ApplicationController < ActionController::Base
       redirect_to "https://www.#{request.host_with_port}#{request.fullpath}", status: 301
     end
   end
+
+  private
+
+  def current_event
+    @current_event = Event.current
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_filter :current_event, only: :index
+
   def create
     er = EventRegistration.new
     er.user = current_user

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   before_filter :login_required, only: [:dashboard]
+  before_filter :current_event, only: :index
 
   def dashboard
     @favorite_projects = current_user.favorites

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  before_filter :current_event, only: :index
+
   def index
     @featured_projects =
       if params[:tags].present?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,10 @@ class Event < ActiveRecord::Base
     upcoming_events.public_events.order('start_date').first
   end
 
+  def self.current
+    Event.where("start_date <= ? AND end_date >= ?", Time.now, Time.now).first
+  end
+
   def logo_delete
     @logo_delete || '0'
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ActiveRecord::Base
   end
 
   def self.current
-    Event.where("start_date <= ? AND end_date >= ?", Time.now, Time.now).first
+    Event.public_events.where("start_date <= ? AND end_date >= ?", Time.now, Time.now).first
   end
 
   def logo_delete

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,9 +32,8 @@ class Event < ActiveRecord::Base
   end
 
   def self.current
-    public_events
-      .where("start_date <= ? AND end_date >= ?", Time.now, Time.now)
-      .first
+    public_events.
+      where("start_date <= ? AND end_date >= ?", Time.now, Time.now).first
   end
 
   def logo_delete

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,9 @@ class Event < ActiveRecord::Base
   end
 
   def self.current
-    Event.public_events.where("start_date <= ? AND end_date >= ?", Time.now, Time.now).first
+    public_events
+      .where("start_date <= ? AND end_date >= ?", Time.now, Time.now)
+      .first
   end
 
   def logo_delete

--- a/app/views/events/_check_in_prompt.html.erb
+++ b/app/views/events/_check_in_prompt.html.erb
@@ -1,0 +1,22 @@
+<% if current_user && @current_event && !current_user.events.include?(@current_event) %>
+  <div id="check_in_prompt" class="reveal-modal index panel radius shadow" data-reveal>
+    <div class="large-12 large-centered row">
+      <% if @current_event.logo_file_name %>
+        <div id="event_logo" class="large-4 columns">
+          <%= link_to (image_tag @current_event.logo, :height => "400px"), event_path(@current_event) %>
+        </div>
+      <% end %>
+      <div class="large-8 columns large-centered text-center">
+        <p><strong>Welcome!</strong> Are you joining us for:</p>
+        <h2><%= link_to @current_event.name, event_path(@current_event) %></h2>
+        <span class="check_in">
+          <% if current_user.events.include?(@current_event) %>
+            <p><i class="fi-check"></i> Checked In<p>
+          <% else %>
+            <%= link_to '<i class="fi-check"></i> &nbsp;Check In Now'.html_safe, events_path(:short_code => @current_event.short_code), remote: true, method: :post, class: "large radius index button centered check-in" %>
+          <% end %>
+        </span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/events/_check_in_prompt.html.erb
+++ b/app/views/events/_check_in_prompt.html.erb
@@ -1,22 +1,21 @@
-<% if current_user && @current_event && !current_user.events.include?(@current_event) %>
-  <div id="check_in_prompt" class="reveal-modal index panel radius shadow" data-reveal>
-    <div class="large-12 large-centered row">
-      <% if @current_event.logo_file_name %>
-        <div id="event_logo" class="large-4 columns">
-          <%= link_to (image_tag @current_event.logo, :height => "400px"), event_path(@current_event) %>
-        </div>
-      <% end %>
-      <div class="large-8 columns large-centered text-center">
-        <p><strong>Welcome!</strong> Are you joining us for:</p>
-        <h2><%= link_to @current_event.name, event_path(@current_event) %></h2>
-        <span class="check_in">
-          <% if current_user.events.include?(@current_event) %>
-            <p><i class="fi-check"></i> Checked In<p>
-          <% else %>
-            <%= link_to '<i class="fi-check"></i> &nbsp;Check In Now'.html_safe, events_path(:short_code => @current_event.short_code), remote: true, method: :post, class: "large radius index button centered check-in" %>
-          <% end %>
-        </span>
+<div id="check_in_prompt" class="reveal-modal index panel radius shadow" data-reveal>
+  <div class="large-12 large-centered row">
+    <% if @current_event.logo_file_name %>
+      <div id="event_logo" class="large-4 columns">
+        <%= link_to (image_tag @current_event.logo, :height => "400px"), event_path(@current_event) %>
       </div>
+    <% end %>
+    <div class="large-8 columns large-centered text-center">
+      <p><strong>Welcome!</strong> Are you joining us for:</p>
+      <h2><%= link_to @current_event.name, event_path(@current_event) %></h2>
+      <span class="check_in">
+        <% if current_user.events.include?(@current_event) %>
+          <p><i class="fi-check"></i> Checked In<p>
+        <% else %>
+          <%= link_to '<i class="fi-check"></i> &nbsp;Check In Now'.html_safe, events_path(:short_code => @current_event.short_code), remote: true, method: :post, class: "large radius index button centered check-in" %>
+        <% end %>
+      </span>
     </div>
   </div>
-<% end %>
+  <a class="close-reveal-modal">&#215;</a>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -18,4 +18,6 @@
     <% end %>
     </div>
   </div>
+
+  <%= render "check_in_prompt" %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -19,5 +19,7 @@
     </div>
   </div>
 
-  <%= render "check_in_prompt" %>
+  <% if current_user && @current_event && !current_user.events.include?(@current_event) %>
+    <%= render "check_in_prompt" %>
+  <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,20 +5,20 @@
       <div id="mission" class="large-10 large-centered columns row">
           <%= image_tag("left_curly.jpg", :class => "small-1 large-2 columns") %>
           <span class="mission_text small-2 large-9 columns">
-            <span id="cm_logo_code">{code}</span> 
-            <span id="cm_logo_montage">montage</span> 
-            empowers 
+            <span id="cm_logo_code">{code}</span>
+            <span id="cm_logo_montage">montage</span>
+            empowers
             <span id="coders" title="software developers, engineers, hackers, anyone who leverages computer programming">
               <strong>coders</strong>
-            </span> 
-            to improve their 
+            </span>
+            to improve their
             <span id="impact" title="success, difference, good accomplished">
               <strong>impact</strong>
             </span> on the world.
           </span>
           <%= image_tag("right_curly.jpg", :class => "small-1 large-2 columns") %>
       </div>
-      
+
     </div>
   </section>
   <section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -71,5 +71,10 @@
       </div>
     </div>
   </section>
+
+  <% if current_user && @current_event && !current_user.events.include?(@current_event) %>
+    <%= render "events/check_in_prompt" %>
+  <% end %>
+
   <% content_for(:press) do %>Press<% end %>
 </body>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -18,4 +18,8 @@
     <h6>Looking for something else?</h6>
     <p>Check out our <%= link_to "resources", resources_path %> to connect with other ways to learn, code, and do good.</p>
   </div>
+
+  <% if current_user && @current_event && !current_user.events.include?(@current_event) %>
+    <%= render "events/check_in_prompt" %>
+  <% end %>
 </div>


### PR DESCRIPTION
- Adds backend `Event` functionality to return a currently-scheduled event (or nil)
- At times when there is no currently-scheduled event, nothing unusual happens
- At times when there is a currently-scheduled event and the user is logged in:
  - the user gets prompted to check in on `/events`, `/projects` & `/` via a modal
  - the user gets immediate feedback when the check in has occurred
  - the user will not get prompted after they've checked in

It would be nice to have some feature tests for this functionality. One day, some day. But in the meantime, experiential proof:

*On the Events page*
![screenshot 2015-01-23 01 44 19](https://cloud.githubusercontent.com/assets/2766324/5871198/8015088c-a2a7-11e4-8618-94bd0b9cc302.png)

*On the Home page*
![screenshot 2015-01-23 01 57 22](https://cloud.githubusercontent.com/assets/2766324/5871199/8014ffcc-a2a7-11e4-913c-2a3bb2c965c9.png)

*On the Projects page*
![screenshot 2015-01-23 01 57 47](https://cloud.githubusercontent.com/assets/2766324/5871201/8018f8b6-a2a7-11e4-9a3c-a857a06673a9.png)

*Checked in*
![screenshot 2015-01-23 01 58 25](https://cloud.githubusercontent.com/assets/2766324/5871200/80152272-a2a7-11e4-86ad-91bb8a5b1a17.png)