### PR TITLE
Fetch GitHub stats

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -65,6 +65,31 @@ class Event < ActiveRecord::Base
     stats
   end
 
+  def total_github_stats
+    github_metrics = [:pull_requests, :commits, :issues, :forks]
+    stats = {}
+
+    github_metrics.each do |metric|
+      stats[metric] = 0
+
+      attendee_github_stats.each do |_user, user_stats|
+        stats[metric] += user_stats[metric] if user_stats
+      end
+    end
+
+    stats
+  end
+
+  def fetch_github_stats
+    stats = {}
+
+    stats[:by_attendee] = attendee_github_stats
+    stats[:by_project] = project_github_stats
+    stats[:total] = total_github_stats
+
+    stats
+  end
+
   private
 
   def delete_logo

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -40,6 +40,11 @@ class Event < ActiveRecord::Base
     @logo_delete || '0'
   end
 
+  def github_api_args
+    { day_begin: start_date,
+      day_end:   end_date }
+  end
+
   private
 
   def delete_logo

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,6 +45,26 @@ class Event < ActiveRecord::Base
       day_end:   end_date }
   end
 
+  def attendee_github_stats
+    stats = {}
+
+    event_registrations.each do |er|
+      stats.merge!(er.user.email => er.fetch_github_stats)
+    end
+
+    stats
+  end
+
+  def project_github_stats
+    stats = {}
+
+    featured_projects.each do |fp|
+      stats.merge!(fp.project.name => fp.fetch_github_stats)
+    end
+
+    stats
+  end
+
   private
 
   def delete_logo

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -4,18 +4,17 @@ class EventRegistration < ActiveRecord::Base
 
   attr_accessible :event_id, :user_id
 
-  def stats
+  def fetch_github_stats
     if github_api_args
       args = github_api_args
-      github_client = Github.new
-      results = {}
+      stats = {}
 
-      results[:prs]     = github_client.pull_requests_by_user(args).count
-      results[:issues]  = github_client.issues_by_user(args).count
-      results[:commits] = github_client.commits_by_user(args).count
-      results[:forks]   = github_client.forks_by_user(args).count
+      stats[:pull_requests] = user.github_pull_requests(args).count
+      stats[:issues]        = user.github_issues(args).count
+      stats[:commits]       = user.github_commits(args).count
+      stats[:forks]         = user.github_forks(args).count
 
-      results
+      stats
     else
       nil
     end

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -22,8 +22,7 @@ class EventRegistration < ActiveRecord::Base
 
   def github_api_args
     if user.github_api_args
-      user.github_api_args.merge!(day_begin: event.start_date,
-                                  day_end: event.end_date)
+      user.github_api_args.merge!(event.github_api_args)
     else
       nil
     end

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -19,7 +19,6 @@ class FeaturedProject < ActiveRecord::Base
   end
 
   def github_api_args
-    project.github_api_args.merge!(day_begin: event.start_date,
-                                   day_end: event.end_date)
+    project.github_api_args.merge!(event.github_api_args)
   end
 end

--- a/app/models/featured_project.rb
+++ b/app/models/featured_project.rb
@@ -6,6 +6,18 @@ class FeaturedProject < ActiveRecord::Base
 
   attr_accessible :project_id, :event_id
 
+  def fetch_github_stats
+    args = github_api_args
+    stats = {}
+
+    stats[:pull_requests] = project.github_pull_requests(args).count
+    stats[:commits]       = project.github_commits(args).count
+    stats[:issues]        = project.github_issues(args).count
+    stats[:forks]         = project.github_forks(args).count
+
+    stats
+  end
+
   def github_api_args
     project.github_api_args.merge!(day_begin: event.start_date,
                                    day_end: event.end_date)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,6 +35,22 @@ class Project < ActiveRecord::Base
       day_end: Time.now }
   end
 
+  def github_pull_requests(args = github_api_args)
+    Github.new.pull_requests_by_repo(args)
+  end
+
+  def github_commits(args = github_api_args)
+    Github.new.commits_by_repo(args)
+  end
+
+  def github_issues(args = github_api_args)
+    Github.new.issues_by_repo(args)
+  end
+
+  def github_forks(args = github_api_args)
+    Github.new.forks_by_repo(args)
+  end
+
   def related_projects
     organization.projects.where('id != ?', id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,22 @@ class User < ActiveRecord::Base
     end
   end
 
+  def github_pull_requests(args = github_api_args)
+    Github.new.pull_requests_by_user(args) if has_github
+  end
+
+  def github_commits(args = github_api_args)
+    Github.new.commits_by_user(args) if has_github
+  end
+
+  def github_issues(args = github_api_args)
+    Github.new.issues_by_user(args) if has_github
+  end
+
+  def github_forks(args = github_api_args)
+    Github.new.forks_by_user(args) if has_github
+  end
+
   protected
 
   def create_profile

--- a/spec/cassettes/codemontage_oct_stats.yml
+++ b/spec/cassettes/codemontage_oct_stats.yml
@@ -1,0 +1,488 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=repo%3ACodeMontageHQ%2Fcodemontage+type%3Apr++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:37 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '30'
+      x-ratelimit-remaining:
+      - '29'
+      x-ratelimit-reset:
+      - '1422058537'
+      cache-control:
+      - no-cache
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2984:A7D363A:54C2E3ED
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      vary:
+      - Accept-Encoding
+      x-served-by:
+      - a241e1a8264a6ace03db946c85b92db3
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"total_count":2,"incomplete_results":false,"items":[{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/events","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/265","id":47349718,"number":265,"title":"Rails
+        4 Prep: Remove match routes","user":{"login":"DBNess","id":226228,"avatar_url":"https://avatars.githubusercontent.com/u/226228?v=3","gravatar_id":"","url":"https://api.github.com/users/DBNess","html_url":"https://github.com/DBNess","followers_url":"https://api.github.com/users/DBNess/followers","following_url":"https://api.github.com/users/DBNess/following{/other_user}","gists_url":"https://api.github.com/users/DBNess/gists{/gist_id}","starred_url":"https://api.github.com/users/DBNess/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/DBNess/subscriptions","organizations_url":"https://api.github.com/users/DBNess/orgs","repos_url":"https://api.github.com/users/DBNess/repos","events_url":"https://api.github.com/users/DBNess/events{/privacy}","received_events_url":"https://api.github.com/users/DBNess/received_events","type":"User","site_admin":false},"labels":[],"state":"closed","locked":false,"assignee":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"milestone":null,"comments":1,"created_at":"2014-10-31T00:50:30Z","updated_at":"2014-10-31T01:47:03Z","closed_at":"2014-10-31T01:47:03Z","pull_request":{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/265","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/265","diff_url":"https://github.com/CodeMontageHQ/codemontage/pull/265.diff","patch_url":"https://github.com/CodeMontageHQ/codemontage/pull/265.patch"},"body":"####
+        [''match'' is deprecated in Rails v4 routing](https://github.com/rails/rails/issues/5964),
+        so let''s clean up these instances as we prepare to upgrade\r\n\r\n![cleanup](https://cloud.githubusercontent.com/assets/226228/4854705/b92f9f44-6097-11e4-9346-f225e031aba2.gif)\r\n","score":1.0},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/events","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/264","id":47164270,"number":264,"title":"Add
+        organizations controller helper","user":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"labels":[],"state":"closed","locked":false,"assignee":null,"milestone":null,"comments":0,"created_at":"2014-10-29T15:43:24Z","updated_at":"2014-10-29T15:45:26Z","closed_at":"2014-10-29T15:45:26Z","pull_request":{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/264","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/264","diff_url":"https://github.com/CodeMontageHQ/codemontage/pull/264.diff","patch_url":"https://github.com/CodeMontageHQ/codemontage/pull/264.patch"},"body":"-
+        Ensure github url is working (no 404)\r\n- Ensure github url is github\r\n-
+        Parse github url for organization account\r\n- Parse github url for project
+        repo name\r\n- Return error message if url is wrong.\r\n\r\n(Do not merge.
+        This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
+        \r\n","score":1.0}]}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=repo%3ACodeMontageHQ%2Fcodemontage+type%3Apr++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:37 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '30'
+      x-ratelimit-remaining:
+      - '28'
+      x-ratelimit-reset:
+      - '1422058537'
+      cache-control:
+      - no-cache
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2985:B49287E:54C2E3ED
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      vary:
+      - Accept-Encoding
+      x-served-by:
+      - 7f48e2f7761567e923121f17538d7a6d
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"total_count":2,"incomplete_results":false,"items":[{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/265/events","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/265","id":47349718,"number":265,"title":"Rails
+        4 Prep: Remove match routes","user":{"login":"DBNess","id":226228,"avatar_url":"https://avatars.githubusercontent.com/u/226228?v=3","gravatar_id":"","url":"https://api.github.com/users/DBNess","html_url":"https://github.com/DBNess","followers_url":"https://api.github.com/users/DBNess/followers","following_url":"https://api.github.com/users/DBNess/following{/other_user}","gists_url":"https://api.github.com/users/DBNess/gists{/gist_id}","starred_url":"https://api.github.com/users/DBNess/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/DBNess/subscriptions","organizations_url":"https://api.github.com/users/DBNess/orgs","repos_url":"https://api.github.com/users/DBNess/repos","events_url":"https://api.github.com/users/DBNess/events{/privacy}","received_events_url":"https://api.github.com/users/DBNess/received_events","type":"User","site_admin":false},"labels":[],"state":"closed","locked":false,"assignee":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"milestone":null,"comments":1,"created_at":"2014-10-31T00:50:30Z","updated_at":"2014-10-31T01:47:03Z","closed_at":"2014-10-31T01:47:03Z","pull_request":{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/265","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/265","diff_url":"https://github.com/CodeMontageHQ/codemontage/pull/265.diff","patch_url":"https://github.com/CodeMontageHQ/codemontage/pull/265.patch"},"body":"####
+        [''match'' is deprecated in Rails v4 routing](https://github.com/rails/rails/issues/5964),
+        so let''s clean up these instances as we prepare to upgrade\r\n\r\n![cleanup](https://cloud.githubusercontent.com/assets/226228/4854705/b92f9f44-6097-11e4-9346-f225e031aba2.gif)\r\n","score":1.0},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/264/events","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/264","id":47164270,"number":264,"title":"Add
+        organizations controller helper","user":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"labels":[],"state":"closed","locked":false,"assignee":null,"milestone":null,"comments":0,"created_at":"2014-10-29T15:43:24Z","updated_at":"2014-10-29T15:45:26Z","closed_at":"2014-10-29T15:45:26Z","pull_request":{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/264","html_url":"https://github.com/CodeMontageHQ/codemontage/pull/264","diff_url":"https://github.com/CodeMontageHQ/codemontage/pull/264.diff","patch_url":"https://github.com/CodeMontageHQ/codemontage/pull/264.patch"},"body":"-
+        Ensure github url is working (no 404)\r\n- Ensure github url is github\r\n-
+        Parse github url for organization account\r\n- Parse github url for project
+        repo name\r\n- Return error message if url is wrong.\r\n\r\n(Do not merge.
+        This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
+        \r\n","score":1.0}]}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:37 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/265/commits?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:42 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4999'
+      x-ratelimit-reset:
+      - '1422062082'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Fri, 23 Jan 2015 23:18:15 GMT
+      etag:
+      - W/"1032341704b30a50d4704872b7add543"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2983:9285B68:54C2E3EE
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - 4c8b2d4732c413f4b9aefe394bd65569
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '[{"sha":"770825089357f323976fe001ad8ba567076d4b78","commit":{"author":{"name":"Vanessa
+        Hurst","email":"vrhurst@gmail.com","date":"2014-10-31T00:44:37Z"},"committer":{"name":"Vanessa
+        Hurst","email":"vrhurst@gmail.com","date":"2014-10-31T00:44:37Z"},"message":"replace
+        ''match'' routes with ''get'' to prep for rails 4 routing","tree":{"sha":"78e06f1295746702c783eb59a6dc2d08d64e343a","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/trees/78e06f1295746702c783eb59a6dc2d08d64e343a"},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/commits/770825089357f323976fe001ad8ba567076d4b78","comment_count":0},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/770825089357f323976fe001ad8ba567076d4b78","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/770825089357f323976fe001ad8ba567076d4b78","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/770825089357f323976fe001ad8ba567076d4b78/comments","author":null,"committer":null,"parents":[{"sha":"26afe69871dc2c86578ac2c6fb45a060eed39e0e","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/26afe69871dc2c86578ac2c6fb45a060eed39e0e","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/26afe69871dc2c86578ac2c6fb45a060eed39e0e"}]},{"sha":"12c7ac3ffe2818a3a7bd8564b23003e98d3aa31a","commit":{"author":{"name":"Vanessa
+        Hurst","email":"vrhurst@gmail.com","date":"2014-10-31T00:46:02Z"},"committer":{"name":"Vanessa
+        Hurst","email":"vrhurst@gmail.com","date":"2014-10-31T00:46:02Z"},"message":"remove
+        unused devise route","tree":{"sha":"a4af5a9b0c7f5be5403da310b5abdef48fb4898a","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/trees/a4af5a9b0c7f5be5403da310b5abdef48fb4898a"},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/commits/12c7ac3ffe2818a3a7bd8564b23003e98d3aa31a","comment_count":0},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/12c7ac3ffe2818a3a7bd8564b23003e98d3aa31a","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/12c7ac3ffe2818a3a7bd8564b23003e98d3aa31a","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/12c7ac3ffe2818a3a7bd8564b23003e98d3aa31a/comments","author":null,"committer":null,"parents":[{"sha":"770825089357f323976fe001ad8ba567076d4b78","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/770825089357f323976fe001ad8ba567076d4b78","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/770825089357f323976fe001ad8ba567076d4b78"}]}]'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:42 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/264/commits?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:43 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4998'
+      x-ratelimit-reset:
+      - '1422062082'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Fri, 23 Jan 2015 23:17:29 GMT
+      etag:
+      - W/"b3140404942b137333814f6b17fe327a"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2981:58591D0:54C2E3F3
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - 2811da37fbdda4367181b328b22b2499
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '[{"sha":"3e9a9ed06a2185fde292cc9b635dc07759597327","commit":{"author":{"name":"Courteney
+        Ervin","email":"courteney.ervin@gmail.com","date":"2014-10-29T15:37:47Z"},"committer":{"name":"Courteney
+        Ervin","email":"courteney.ervin@gmail.com","date":"2014-10-29T15:37:47Z"},"message":"Add
+        organizations controller helper\n\n- Ensure github url is working (no 404)\n-
+        Ensure github url is github\n- Parse github url for organization account\n-
+        Parse github url for project repo name\n- Return error message if url is wrong.","tree":{"sha":"2d1815abc4ea59f6a4170ec0603e09c5ed4816a9","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/trees/2d1815abc4ea59f6a4170ec0603e09c5ed4816a9"},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","comment_count":0},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/3e9a9ed06a2185fde292cc9b635dc07759597327","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327/comments","author":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"committer":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"parents":[{"sha":"26afe69871dc2c86578ac2c6fb45a060eed39e0e","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/26afe69871dc2c86578ac2c6fb45a060eed39e0e","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/26afe69871dc2c86578ac2c6fb45a060eed39e0e"}]}]'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:43 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=repo%3ACodeMontageHQ%2Fcodemontage+type%3Aissue++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:43 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '30'
+      x-ratelimit-remaining:
+      - '27'
+      x-ratelimit-reset:
+      - '1422058537'
+      cache-control:
+      - no-cache
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2985:B49321D:54C2E3F3
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      vary:
+      - Accept-Encoding
+      x-served-by:
+      - d594a23ec74671eba905bf91ef329026
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"total_count":3,"incomplete_results":false,"items":[{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/266","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/266/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/266/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/266/events","html_url":"https://github.com/CodeMontageHQ/codemontage/issues/266","id":47350485,"number":266,"title":"Change
+        ''Devs For Good Meetup'' link label to ''NYC Meetup''","user":{"login":"DBNess","id":226228,"avatar_url":"https://avatars.githubusercontent.com/u/226228?v=3","gravatar_id":"","url":"https://api.github.com/users/DBNess","html_url":"https://github.com/DBNess","followers_url":"https://api.github.com/users/DBNess/followers","following_url":"https://api.github.com/users/DBNess/following{/other_user}","gists_url":"https://api.github.com/users/DBNess/gists{/gist_id}","starred_url":"https://api.github.com/users/DBNess/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/DBNess/subscriptions","organizations_url":"https://api.github.com/users/DBNess/orgs","repos_url":"https://api.github.com/users/DBNess/repos","events_url":"https://api.github.com/users/DBNess/events{/privacy}","received_events_url":"https://api.github.com/users/DBNess/received_events","type":"User","site_admin":false},"labels":[{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/labels/frontend","name":"frontend","color":"fad8c7"},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/labels/high%20priority","name":"high
+        priority","color":"fbca04"}],"state":"closed","locked":false,"assignee":null,"milestone":null,"comments":0,"created_at":"2014-10-31T01:00:06Z","updated_at":"2014-11-05T14:34:11Z","closed_at":"2014-11-05T14:34:11Z","body":"####
+        Update this:\r\n\r\n![codemontage](https://cloud.githubusercontent.com/assets/226228/4854764/b53bc592-6098-11e4-9982-20dbbaa7bf62.png)\r\n\r\n####
+        because we''ve merged Developers for Good into the CodeMontage community:\r\n\r\n![codemontage_blog__five_years___developers_for_good____codemontage___open_source_](https://cloud.githubusercontent.com/assets/226228/4854786/176c798c-6099-11e4-8120-7e0ae14ea842.png)\r\n![coders_for_good__formerly_developers_for_good___new_york__ny__-_meetup](https://cloud.githubusercontent.com/assets/226228/4854787/18d9f470-6099-11e4-8c1b-effa0ea14596.png)\r\n","score":1.0},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/263","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/263/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/263/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/263/events","html_url":"https://github.com/CodeMontageHQ/codemontage/issues/263","id":47066536,"number":263,"title":"GitHub
+        signup redirects to login instead of authorizing new user","user":{"login":"jarmstrng","id":7620750,"avatar_url":"https://avatars.githubusercontent.com/u/7620750?v=3","gravatar_id":"","url":"https://api.github.com/users/jarmstrng","html_url":"https://github.com/jarmstrng","followers_url":"https://api.github.com/users/jarmstrng/followers","following_url":"https://api.github.com/users/jarmstrng/following{/other_user}","gists_url":"https://api.github.com/users/jarmstrng/gists{/gist_id}","starred_url":"https://api.github.com/users/jarmstrng/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jarmstrng/subscriptions","organizations_url":"https://api.github.com/users/jarmstrng/orgs","repos_url":"https://api.github.com/users/jarmstrng/repos","events_url":"https://api.github.com/users/jarmstrng/events{/privacy}","received_events_url":"https://api.github.com/users/jarmstrng/received_events","type":"User","site_admin":false},"labels":[],"state":"closed","locked":false,"assignee":null,"milestone":null,"comments":10,"created_at":"2014-10-28T18:55:22Z","updated_at":"2014-12-30T00:01:55Z","closed_at":"2014-12-30T00:01:55Z","body":"Clicking
+        the Sign Up with GitHub button redirects to https://www.codemontage.com/auth/login.","score":1.0},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/262","labels_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/262/labels{/name}","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/262/comments","events_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/issues/262/events","html_url":"https://github.com/CodeMontageHQ/codemontage/issues/262","id":46182473,"number":262,"title":"Add
+        Code of Conduct Note to Individual Event Pages","user":{"login":"DBNess","id":226228,"avatar_url":"https://avatars.githubusercontent.com/u/226228?v=3","gravatar_id":"","url":"https://api.github.com/users/DBNess","html_url":"https://github.com/DBNess","followers_url":"https://api.github.com/users/DBNess/followers","following_url":"https://api.github.com/users/DBNess/following{/other_user}","gists_url":"https://api.github.com/users/DBNess/gists{/gist_id}","starred_url":"https://api.github.com/users/DBNess/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/DBNess/subscriptions","organizations_url":"https://api.github.com/users/DBNess/orgs","repos_url":"https://api.github.com/users/DBNess/repos","events_url":"https://api.github.com/users/DBNess/events{/privacy}","received_events_url":"https://api.github.com/users/DBNess/received_events","type":"User","site_admin":false},"labels":[{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/labels/design","name":"design","color":"0052cc"},{"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/labels/enhancement","name":"enhancement","color":"1aacbc"}],"state":"open","locked":false,"assignee":null,"milestone":null,"comments":0,"created_at":"2014-10-18T17:45:33Z","updated_at":"2014-10-18T17:47:25Z","closed_at":null,"body":"Each
+        individual event landing page should have a note highlighting the code of
+        conduct (basically the reverse use case of the same information added to the
+        Code of Conduct page in #252 Update Code of Conduct to Show Upcoming Events
+        & PR #255)","score":1.0}]}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:43 GMT
+- request:
+    method: get
+    uri: https://api.github.com/search/repositories?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=codemontage+in%3Aname+fork%3Aonly+++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 00:14:47 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '30'
+      x-ratelimit-remaining:
+      - '26'
+      x-ratelimit-reset:
+      - '1422058537'
+      cache-control:
+      - no-cache
+      x-github-media-type:
+      - github.v3; format=json
+      link:
+      - <https://api.github.com/search/repositories?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=codemontage+in%3Aname+fork%3Aonly+++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100&page=0>;
+        rel="last"
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:2983:9286523:54C2E3F6
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      vary:
+      - Accept-Encoding
+      x-served-by:
+      - 2811da37fbdda4367181b328b22b2499
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"total_count":0,"incomplete_results":false,"items":[]}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 00:14:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/courte_oct_stats.yml
+++ b/spec/cassettes/courte_oct_stats.yml
@@ -23,7 +23,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:54 GMT
+      - Fri, 23 Jan 2015 23:27:49 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -35,15 +35,15 @@ http_interactions:
       x-ratelimit-limit:
       - '5000'
       x-ratelimit-remaining:
-      - '4993'
+      - '4997'
       x-ratelimit-reset:
-      - '1422041915'
+      - '1422058368'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 18:00:05 GMT
+      - Fri, 23 Jan 2015 23:17:29 GMT
       etag:
-      - W/"7409a1ac7d607892b94157ebf33b71b0"
+      - W/"2f15a3149ae32816c83b04690cd7bfae"
       vary:
       - Accept
       - Accept-Encoding
@@ -63,20 +63,20 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6C:8B206B4:54C29796
+      - 4C758B1E:1D69:3E0E371:54C2D8F5
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - a30e6f9aa7cf5731b87dfb3b9992202d
+      - a241e1a8264a6ace03db946c85b92db3
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T18:00:05Z"}'
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:54 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:49 GMT
 - request:
     method: get
     uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
@@ -100,7 +100,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:54 GMT
+      - Fri, 23 Jan 2015 23:27:49 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -112,15 +112,15 @@ http_interactions:
       x-ratelimit-limit:
       - '5000'
       x-ratelimit-remaining:
-      - '4992'
+      - '4996'
       x-ratelimit-reset:
-      - '1422041915'
+      - '1422058368'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 18:00:05 GMT
+      - Fri, 23 Jan 2015 23:17:29 GMT
       etag:
-      - W/"7409a1ac7d607892b94157ebf33b71b0"
+      - W/"2f15a3149ae32816c83b04690cd7bfae"
       vary:
       - Accept
       - Accept-Encoding
@@ -140,20 +140,174 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6D:9DDFF79:54C29796
+      - 4C758B1E:1D6E:AF71BAA:54C2D8F5
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - 07ff1c8a09e44b62e277fae50a1b1dc4
+      - 065b43cd9674091fec48a221b420fbb3
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T18:00:05Z"}'
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:54 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:49 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Fri, 23 Jan 2015 23:27:56 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4995'
+      x-ratelimit-reset:
+      - '1422058368'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Fri, 23 Jan 2015 23:17:29 GMT
+      etag:
+      - W/"2f15a3149ae32816c83b04690cd7bfae"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:1D6C:9126DD1:54C2D8FB
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - d594a23ec74671eba905bf91ef329026
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
+    http_version: '1.1'
+  recorded_at: Fri, 23 Jan 2015 23:27:55 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Fri, 23 Jan 2015 23:27:56 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4994'
+      x-ratelimit-reset:
+      - '1422058368'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Fri, 23 Jan 2015 23:17:29 GMT
+      etag:
+      - W/"2f15a3149ae32816c83b04690cd7bfae"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:1D6F:66BFA5A:54C2D8FC
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - 4c8b2d4732c413f4b9aefe394bd65569
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
+    http_version: '1.1'
+  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
 - request:
     method: get
     uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
@@ -177,7 +331,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:54 GMT
+      - Fri, 23 Jan 2015 23:27:56 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -191,7 +345,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '29'
       x-ratelimit-reset:
-      - '1422038994'
+      - '1422055736'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -210,7 +364,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6C:8B2075E:54C29796
+      - 4C758B1E:1D6E:AF72608:54C2D8FC
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -218,7 +372,7 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - 76d9828c7e4f1d910f7ba069e90ce976
+      - c6c65e5196703428e7641f7d1e9bc353
       content-encoding:
       - gzip
     body:
@@ -231,7 +385,7 @@ http_interactions:
         This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
         \r\n","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:54 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
 - request:
     method: get
     uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Aissue++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
@@ -255,7 +409,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:54 GMT
+      - Fri, 23 Jan 2015 23:27:57 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -269,7 +423,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '28'
       x-ratelimit-reset:
-      - '1422038994'
+      - '1422055736'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -291,7 +445,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6E:A839980:54C29796
+      - 4C758B1E:1D69:3E0E570:54C2D8FC
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -299,14 +453,14 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - 2811da37fbdda4367181b328b22b2499
+      - 318e55760cf7cdb40e61175a4d36cd32
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
       string: '{"total_count":0,"incomplete_results":false,"items":[]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:54 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
 - request:
     method: get
     uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
@@ -330,7 +484,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:55 GMT
+      - Fri, 23 Jan 2015 23:27:57 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -344,7 +498,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '27'
       x-ratelimit-reset:
-      - '1422038994'
+      - '1422055736'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -363,7 +517,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6A:567FED2:54C29797
+      - 4C758B1E:1D6D:A4AC236:54C2D8FD
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -384,7 +538,7 @@ http_interactions:
         This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
         \r\n","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:55 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:57 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/264/commits?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&per_page=100
@@ -408,7 +562,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:55 GMT
+      - Fri, 23 Jan 2015 23:27:57 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -420,13 +574,13 @@ http_interactions:
       x-ratelimit-limit:
       - '5000'
       x-ratelimit-remaining:
-      - '4991'
+      - '4993'
       x-ratelimit-reset:
-      - '1422041915'
+      - '1422058368'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 18:00:05 GMT
+      - Fri, 23 Jan 2015 23:17:29 GMT
       etag:
       - W/"b3140404942b137333814f6b17fe327a"
       vary:
@@ -448,13 +602,13 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6E:A839A92:54C29797
+      - 4C758B1E:1D68:2784DA6:54C2D8FD
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - 01d096e6cfe28f8aea352e988c332cd3
+      - a241e1a8264a6ace03db946c85b92db3
       content-encoding:
       - gzip
     body:
@@ -466,7 +620,7 @@ http_interactions:
         Ensure github url is github\n- Parse github url for organization account\n-
         Parse github url for project repo name\n- Return error message if url is wrong.","tree":{"sha":"2d1815abc4ea59f6a4170ec0603e09c5ed4816a9","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/trees/2d1815abc4ea59f6a4170ec0603e09c5ed4816a9"},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","comment_count":0},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/3e9a9ed06a2185fde292cc9b635dc07759597327","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327/comments","author":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"committer":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"parents":[{"sha":"26afe69871dc2c86578ac2c6fb45a060eed39e0e","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/26afe69871dc2c86578ac2c6fb45a060eed39e0e","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/26afe69871dc2c86578ac2c6fb45a060eed39e0e"}]}]'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:55 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:57 GMT
 - request:
     method: get
     uri: https://api.github.com/search/repositories?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=user%3Acourte+fork%3Aonly+++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
@@ -490,7 +644,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 18:48:55 GMT
+      - Fri, 23 Jan 2015 23:27:58 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -504,7 +658,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '26'
       x-ratelimit-reset:
-      - '1422038994'
+      - '1422055736'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -523,7 +677,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6B:721365B:54C29797
+      - 4C758B1E:1D6E:AF72922:54C2D8FE
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -531,7 +685,7 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - a30e6f9aa7cf5731b87dfb3b9992202d
+      - b0ef53392caa42315c6206737946d931
       content-encoding:
       - gzip
     body:
@@ -539,5 +693,5 @@ http_interactions:
       string: '{"total_count":2,"incomplete_results":false,"items":[{"id":25838024,"name":"Ospreydit","full_name":"courte/Ospreydit","owner":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/courte/Ospreydit","description":"Reddit
         clone for the Ospreys","fork":true,"url":"https://api.github.com/repos/courte/Ospreydit","forks_url":"https://api.github.com/repos/courte/Ospreydit/forks","keys_url":"https://api.github.com/repos/courte/Ospreydit/keys{/key_id}","collaborators_url":"https://api.github.com/repos/courte/Ospreydit/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/courte/Ospreydit/teams","hooks_url":"https://api.github.com/repos/courte/Ospreydit/hooks","issue_events_url":"https://api.github.com/repos/courte/Ospreydit/issues/events{/number}","events_url":"https://api.github.com/repos/courte/Ospreydit/events","assignees_url":"https://api.github.com/repos/courte/Ospreydit/assignees{/user}","branches_url":"https://api.github.com/repos/courte/Ospreydit/branches{/branch}","tags_url":"https://api.github.com/repos/courte/Ospreydit/tags","blobs_url":"https://api.github.com/repos/courte/Ospreydit/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/courte/Ospreydit/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/courte/Ospreydit/git/refs{/sha}","trees_url":"https://api.github.com/repos/courte/Ospreydit/git/trees{/sha}","statuses_url":"https://api.github.com/repos/courte/Ospreydit/statuses/{sha}","languages_url":"https://api.github.com/repos/courte/Ospreydit/languages","stargazers_url":"https://api.github.com/repos/courte/Ospreydit/stargazers","contributors_url":"https://api.github.com/repos/courte/Ospreydit/contributors","subscribers_url":"https://api.github.com/repos/courte/Ospreydit/subscribers","subscription_url":"https://api.github.com/repos/courte/Ospreydit/subscription","commits_url":"https://api.github.com/repos/courte/Ospreydit/commits{/sha}","git_commits_url":"https://api.github.com/repos/courte/Ospreydit/git/commits{/sha}","comments_url":"https://api.github.com/repos/courte/Ospreydit/comments{/number}","issue_comment_url":"https://api.github.com/repos/courte/Ospreydit/issues/comments/{number}","contents_url":"https://api.github.com/repos/courte/Ospreydit/contents/{+path}","compare_url":"https://api.github.com/repos/courte/Ospreydit/compare/{base}...{head}","merges_url":"https://api.github.com/repos/courte/Ospreydit/merges","archive_url":"https://api.github.com/repos/courte/Ospreydit/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/courte/Ospreydit/downloads","issues_url":"https://api.github.com/repos/courte/Ospreydit/issues{/number}","pulls_url":"https://api.github.com/repos/courte/Ospreydit/pulls{/number}","milestones_url":"https://api.github.com/repos/courte/Ospreydit/milestones{/number}","notifications_url":"https://api.github.com/repos/courte/Ospreydit/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/courte/Ospreydit/labels{/name}","releases_url":"https://api.github.com/repos/courte/Ospreydit/releases{/id}","created_at":"2014-10-27T20:36:49Z","updated_at":"2014-10-27T19:41:32Z","pushed_at":"2014-10-27T19:41:32Z","git_url":"git://github.com/courte/Ospreydit.git","ssh_url":"git@github.com:courte/Ospreydit.git","clone_url":"https://github.com/courte/Ospreydit.git","svn_url":"https://github.com/courte/Ospreydit","homepage":null,"size":72,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":1.0},{"id":24691649,"name":"curriculum","full_name":"courte/curriculum","owner":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/courte/curriculum","description":"","fork":true,"url":"https://api.github.com/repos/courte/curriculum","forks_url":"https://api.github.com/repos/courte/curriculum/forks","keys_url":"https://api.github.com/repos/courte/curriculum/keys{/key_id}","collaborators_url":"https://api.github.com/repos/courte/curriculum/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/courte/curriculum/teams","hooks_url":"https://api.github.com/repos/courte/curriculum/hooks","issue_events_url":"https://api.github.com/repos/courte/curriculum/issues/events{/number}","events_url":"https://api.github.com/repos/courte/curriculum/events","assignees_url":"https://api.github.com/repos/courte/curriculum/assignees{/user}","branches_url":"https://api.github.com/repos/courte/curriculum/branches{/branch}","tags_url":"https://api.github.com/repos/courte/curriculum/tags","blobs_url":"https://api.github.com/repos/courte/curriculum/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/courte/curriculum/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/courte/curriculum/git/refs{/sha}","trees_url":"https://api.github.com/repos/courte/curriculum/git/trees{/sha}","statuses_url":"https://api.github.com/repos/courte/curriculum/statuses/{sha}","languages_url":"https://api.github.com/repos/courte/curriculum/languages","stargazers_url":"https://api.github.com/repos/courte/curriculum/stargazers","contributors_url":"https://api.github.com/repos/courte/curriculum/contributors","subscribers_url":"https://api.github.com/repos/courte/curriculum/subscribers","subscription_url":"https://api.github.com/repos/courte/curriculum/subscription","commits_url":"https://api.github.com/repos/courte/curriculum/commits{/sha}","git_commits_url":"https://api.github.com/repos/courte/curriculum/git/commits{/sha}","comments_url":"https://api.github.com/repos/courte/curriculum/comments{/number}","issue_comment_url":"https://api.github.com/repos/courte/curriculum/issues/comments/{number}","contents_url":"https://api.github.com/repos/courte/curriculum/contents/{+path}","compare_url":"https://api.github.com/repos/courte/curriculum/compare/{base}...{head}","merges_url":"https://api.github.com/repos/courte/curriculum/merges","archive_url":"https://api.github.com/repos/courte/curriculum/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/courte/curriculum/downloads","issues_url":"https://api.github.com/repos/courte/curriculum/issues{/number}","pulls_url":"https://api.github.com/repos/courte/curriculum/pulls{/number}","milestones_url":"https://api.github.com/repos/courte/curriculum/milestones{/number}","notifications_url":"https://api.github.com/repos/courte/curriculum/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/courte/curriculum/labels{/name}","releases_url":"https://api.github.com/repos/courte/curriculum/releases{/id}","created_at":"2014-10-01T19:11:34Z","updated_at":"2014-10-01T12:08:01Z","pushed_at":"2014-11-06T03:03:31Z","git_url":"git://github.com/courte/curriculum.git","ssh_url":"git@github.com:courte/curriculum.git","clone_url":"https://github.com/courte/curriculum.git","svn_url":"https://github.com/courte/curriculum","homepage":null,"size":138,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 18:48:55 GMT
+  recorded_at: Fri, 23 Jan 2015 23:27:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/courte_oct_stats.yml
+++ b/spec/cassettes/courte_oct_stats.yml
@@ -23,7 +23,161 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:49 GMT
+      - Sat, 24 Jan 2015 03:55:04 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4999'
+      x-ratelimit-reset:
+      - '1422075304'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Sat, 24 Jan 2015 03:38:38 GMT
+      etag:
+      - W/"1e5e3dabba50e3c2fdb1c452e724e5c7"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:1675:C1E4B8D:54C31798
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - d594a23ec74671eba905bf91ef329026
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-24T03:38:38Z"}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 03:55:04 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 03:55:05 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4998'
+      x-ratelimit-reset:
+      - '1422075304'
+      cache-control:
+      - public, max-age=60, s-maxage=60
+      last-modified:
+      - Sat, 24 Jan 2015 03:38:38 GMT
+      etag:
+      - W/"1e5e3dabba50e3c2fdb1c452e724e5c7"
+      vary:
+      - Accept
+      - Accept-Encoding
+      x-github-media-type:
+      - github.v3; format=json
+      x-xss-protection:
+      - 1; mode=block
+      x-frame-options:
+      - deny
+      content-security-policy:
+      - default-src 'none'
+      access-control-allow-credentials:
+      - 'true'
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      x-github-request-id:
+      - 4C758B1E:1671:5CC4407:54C31799
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-served-by:
+      - a241e1a8264a6ace03db946c85b92db3
+      content-encoding:
+      - gzip
+    body:
+      encoding: UTF-8
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-24T03:38:38Z"}'
+    http_version: '1.1'
+  recorded_at: Sat, 24 Jan 2015 03:55:05 GMT
+- request:
+    method: get
+    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      accept:
+      - application/vnd.github.v3+json
+      user-agent:
+      - Octokit Ruby Gem 3.5.2
+      content-type:
+      - application/json
+      accept-encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Sat, 24 Jan 2015 03:55:05 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -37,13 +191,13 @@ http_interactions:
       x-ratelimit-remaining:
       - '4997'
       x-ratelimit-reset:
-      - '1422058368'
+      - '1422075304'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 23:17:29 GMT
+      - Sat, 24 Jan 2015 03:38:38 GMT
       etag:
-      - W/"2f15a3149ae32816c83b04690cd7bfae"
+      - W/"1e5e3dabba50e3c2fdb1c452e724e5c7"
       vary:
       - Accept
       - Accept-Encoding
@@ -63,20 +217,20 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D69:3E0E371:54C2D8F5
+      - 4C758B1E:1674:B421B9A:54C31799
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - a241e1a8264a6ace03db946c85b92db3
+      - 7f48e2f7761567e923121f17538d7a6d
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-24T03:38:38Z"}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:49 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:05 GMT
 - request:
     method: get
     uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
@@ -100,7 +254,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:49 GMT
+      - Sat, 24 Jan 2015 03:55:05 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -114,13 +268,13 @@ http_interactions:
       x-ratelimit-remaining:
       - '4996'
       x-ratelimit-reset:
-      - '1422058368'
+      - '1422075304'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 23:17:29 GMT
+      - Sat, 24 Jan 2015 03:38:38 GMT
       etag:
-      - W/"2f15a3149ae32816c83b04690cd7bfae"
+      - W/"1e5e3dabba50e3c2fdb1c452e724e5c7"
       vary:
       - Accept
       - Accept-Encoding
@@ -140,23 +294,23 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6E:AF71BAA:54C2D8F5
+      - 4C758B1E:1676:6663436:54C31799
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - 065b43cd9674091fec48a221b420fbb3
+      - 8a5c38021a5cd7cef7b8f49a296fee40
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
+      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-24T03:38:38Z"}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:49 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:05 GMT
 - request:
     method: get
-    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
     body:
       encoding: US-ASCII
       string: ''
@@ -177,161 +331,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:56 GMT
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-      connection:
-      - close
-      status:
-      - 200 OK
-      x-ratelimit-limit:
-      - '5000'
-      x-ratelimit-remaining:
-      - '4995'
-      x-ratelimit-reset:
-      - '1422058368'
-      cache-control:
-      - public, max-age=60, s-maxage=60
-      last-modified:
-      - Fri, 23 Jan 2015 23:17:29 GMT
-      etag:
-      - W/"2f15a3149ae32816c83b04690cd7bfae"
-      vary:
-      - Accept
-      - Accept-Encoding
-      x-github-media-type:
-      - github.v3; format=json
-      x-xss-protection:
-      - 1; mode=block
-      x-frame-options:
-      - deny
-      content-security-policy:
-      - default-src 'none'
-      access-control-allow-credentials:
-      - 'true'
-      access-control-expose-headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      access-control-allow-origin:
-      - "*"
-      x-github-request-id:
-      - 4C758B1E:1D6C:9126DD1:54C2D8FB
-      strict-transport-security:
-      - max-age=31536000; includeSubdomains; preload
-      x-content-type-options:
-      - nosniff
-      x-served-by:
-      - d594a23ec74671eba905bf91ef329026
-      content-encoding:
-      - gzip
-    body:
-      encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
-    http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:55 GMT
-- request:
-    method: get
-    uri: https://api.github.com/user/2766324?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      accept:
-      - application/vnd.github.v3+json
-      user-agent:
-      - Octokit Ruby Gem 3.5.2
-      content-type:
-      - application/json
-      accept-encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      server:
-      - GitHub.com
-      date:
-      - Fri, 23 Jan 2015 23:27:56 GMT
-      content-type:
-      - application/json; charset=utf-8
-      transfer-encoding:
-      - chunked
-      connection:
-      - close
-      status:
-      - 200 OK
-      x-ratelimit-limit:
-      - '5000'
-      x-ratelimit-remaining:
-      - '4994'
-      x-ratelimit-reset:
-      - '1422058368'
-      cache-control:
-      - public, max-age=60, s-maxage=60
-      last-modified:
-      - Fri, 23 Jan 2015 23:17:29 GMT
-      etag:
-      - W/"2f15a3149ae32816c83b04690cd7bfae"
-      vary:
-      - Accept
-      - Accept-Encoding
-      x-github-media-type:
-      - github.v3; format=json
-      x-xss-protection:
-      - 1; mode=block
-      x-frame-options:
-      - deny
-      content-security-policy:
-      - default-src 'none'
-      access-control-allow-credentials:
-      - 'true'
-      access-control-expose-headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      access-control-allow-origin:
-      - "*"
-      x-github-request-id:
-      - 4C758B1E:1D6F:66BFA5A:54C2D8FC
-      strict-transport-security:
-      - max-age=31536000; includeSubdomains; preload
-      x-content-type-options:
-      - nosniff
-      x-served-by:
-      - 4c8b2d4732c413f4b9aefe394bd65569
-      content-encoding:
-      - gzip
-    body:
-      encoding: UTF-8
-      string: '{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false,"name":"Courteney","company":null,"blog":null,"location":null,"email":null,"hireable":false,"bio":null,"public_repos":16,"public_gists":2,"followers":18,"following":11,"created_at":"2012-11-10T14:07:09Z","updated_at":"2015-01-23T23:17:29Z"}'
-    http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
-- request:
-    method: get
-    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      accept:
-      - application/vnd.github.v3+json
-      user-agent:
-      - Octokit Ruby Gem 3.5.2
-      content-type:
-      - application/json
-      accept-encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      server:
-      - GitHub.com
-      date:
-      - Fri, 23 Jan 2015 23:27:56 GMT
+      - Sat, 24 Jan 2015 03:55:05 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -345,7 +345,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '29'
       x-ratelimit-reset:
-      - '1422055736'
+      - '1422071765'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -364,7 +364,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6E:AF72608:54C2D8FC
+      - 4C758B1E:1675:C1E4DA4:54C31799
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -372,7 +372,7 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - c6c65e5196703428e7641f7d1e9bc353
+      - 8dd185e423974a7e13abbbe6e060031e
       content-encoding:
       - gzip
     body:
@@ -385,10 +385,10 @@ http_interactions:
         This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
         \r\n","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:05 GMT
 - request:
     method: get
-    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Aissue++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Aissue++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
     body:
       encoding: US-ASCII
       string: ''
@@ -409,7 +409,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:57 GMT
+      - Sat, 24 Jan 2015 03:55:06 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -423,13 +423,13 @@ http_interactions:
       x-ratelimit-remaining:
       - '28'
       x-ratelimit-reset:
-      - '1422055736'
+      - '1422071765'
       cache-control:
       - no-cache
       x-github-media-type:
       - github.v3; format=json
       link:
-      - <https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Aissue++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100&page=0>;
+      - <https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Aissue++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100&page=0>;
         rel="last"
       x-xss-protection:
       - 1; mode=block
@@ -445,7 +445,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D69:3E0E570:54C2D8FC
+      - 4C758B1E:1676:66634B0:54C3179A
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -453,17 +453,17 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - 318e55760cf7cdb40e61175a4d36cd32
+      - 8a5c38021a5cd7cef7b8f49a296fee40
       content-encoding:
       - gzip
     body:
       encoding: UTF-8
       string: '{"total_count":0,"incomplete_results":false,"items":[]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:56 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:06 GMT
 - request:
     method: get
-    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    uri: https://api.github.com/search/issues?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=author%3Acourte+type%3Apr++++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
     body:
       encoding: US-ASCII
       string: ''
@@ -484,7 +484,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:57 GMT
+      - Sat, 24 Jan 2015 03:55:06 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -498,7 +498,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '27'
       x-ratelimit-reset:
-      - '1422055736'
+      - '1422071765'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -517,7 +517,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6D:A4AC236:54C2D8FD
+      - 4C758B1E:1674:B421D83:54C3179A
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -525,7 +525,7 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - 13d09b732ebe76f892093130dc088652
+      - 2811da37fbdda4367181b328b22b2499
       content-encoding:
       - gzip
     body:
@@ -538,7 +538,7 @@ http_interactions:
         This ain''t real. Pay no attention to the code behind the helper.) :-1: :frowning:
         \r\n","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:57 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:06 GMT
 - request:
     method: get
     uri: https://api.github.com/repos/CodeMontageHQ/codemontage/pulls/264/commits?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&per_page=100
@@ -562,7 +562,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:57 GMT
+      - Sat, 24 Jan 2015 03:55:06 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -574,13 +574,13 @@ http_interactions:
       x-ratelimit-limit:
       - '5000'
       x-ratelimit-remaining:
-      - '4993'
+      - '4995'
       x-ratelimit-reset:
-      - '1422058368'
+      - '1422075304'
       cache-control:
       - public, max-age=60, s-maxage=60
       last-modified:
-      - Fri, 23 Jan 2015 23:17:29 GMT
+      - Sat, 24 Jan 2015 03:38:38 GMT
       etag:
       - W/"b3140404942b137333814f6b17fe327a"
       vary:
@@ -602,13 +602,13 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D68:2784DA6:54C2D8FD
+      - 4C758B1E:1675:C1E4F56:54C3179A
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
       - nosniff
       x-served-by:
-      - a241e1a8264a6ace03db946c85b92db3
+      - 13d09b732ebe76f892093130dc088652
       content-encoding:
       - gzip
     body:
@@ -620,10 +620,10 @@ http_interactions:
         Ensure github url is github\n- Parse github url for organization account\n-
         Parse github url for project repo name\n- Return error message if url is wrong.","tree":{"sha":"2d1815abc4ea59f6a4170ec0603e09c5ed4816a9","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/trees/2d1815abc4ea59f6a4170ec0603e09c5ed4816a9"},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/git/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","comment_count":0},"url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/3e9a9ed06a2185fde292cc9b635dc07759597327","comments_url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/3e9a9ed06a2185fde292cc9b635dc07759597327/comments","author":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"committer":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"parents":[{"sha":"26afe69871dc2c86578ac2c6fb45a060eed39e0e","url":"https://api.github.com/repos/CodeMontageHQ/codemontage/commits/26afe69871dc2c86578ac2c6fb45a060eed39e0e","html_url":"https://github.com/CodeMontageHQ/codemontage/commit/26afe69871dc2c86578ac2c6fb45a060eed39e0e"}]}]'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:57 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:06 GMT
 - request:
     method: get
-    uri: https://api.github.com/search/repositories?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=user%3Acourte+fork%3Aonly+++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
+    uri: https://api.github.com/search/repositories?client_id=<GITHUB_KEY>&client_secret=<GITHUB_SECRET>&q=user%3Acourte+fork%3Aonly+++++++++++++++++++++++++++++++++++++created%3A2014-10-01..2014-10-31&per_page=100
     body:
       encoding: US-ASCII
       string: ''
@@ -644,7 +644,7 @@ http_interactions:
       server:
       - GitHub.com
       date:
-      - Fri, 23 Jan 2015 23:27:58 GMT
+      - Sat, 24 Jan 2015 03:55:07 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -658,7 +658,7 @@ http_interactions:
       x-ratelimit-remaining:
       - '26'
       x-ratelimit-reset:
-      - '1422055736'
+      - '1422071765'
       cache-control:
       - no-cache
       x-github-media-type:
@@ -677,7 +677,7 @@ http_interactions:
       access-control-allow-origin:
       - "*"
       x-github-request-id:
-      - 4C758B1E:1D6E:AF72922:54C2D8FE
+      - 4C758B1E:1674:B421E8F:54C3179B
       strict-transport-security:
       - max-age=31536000; includeSubdomains; preload
       x-content-type-options:
@@ -685,7 +685,7 @@ http_interactions:
       vary:
       - Accept-Encoding
       x-served-by:
-      - b0ef53392caa42315c6206737946d931
+      - c6c65e5196703428e7641f7d1e9bc353
       content-encoding:
       - gzip
     body:
@@ -693,5 +693,5 @@ http_interactions:
       string: '{"total_count":2,"incomplete_results":false,"items":[{"id":25838024,"name":"Ospreydit","full_name":"courte/Ospreydit","owner":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/courte/Ospreydit","description":"Reddit
         clone for the Ospreys","fork":true,"url":"https://api.github.com/repos/courte/Ospreydit","forks_url":"https://api.github.com/repos/courte/Ospreydit/forks","keys_url":"https://api.github.com/repos/courte/Ospreydit/keys{/key_id}","collaborators_url":"https://api.github.com/repos/courte/Ospreydit/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/courte/Ospreydit/teams","hooks_url":"https://api.github.com/repos/courte/Ospreydit/hooks","issue_events_url":"https://api.github.com/repos/courte/Ospreydit/issues/events{/number}","events_url":"https://api.github.com/repos/courte/Ospreydit/events","assignees_url":"https://api.github.com/repos/courte/Ospreydit/assignees{/user}","branches_url":"https://api.github.com/repos/courte/Ospreydit/branches{/branch}","tags_url":"https://api.github.com/repos/courte/Ospreydit/tags","blobs_url":"https://api.github.com/repos/courte/Ospreydit/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/courte/Ospreydit/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/courte/Ospreydit/git/refs{/sha}","trees_url":"https://api.github.com/repos/courte/Ospreydit/git/trees{/sha}","statuses_url":"https://api.github.com/repos/courte/Ospreydit/statuses/{sha}","languages_url":"https://api.github.com/repos/courte/Ospreydit/languages","stargazers_url":"https://api.github.com/repos/courte/Ospreydit/stargazers","contributors_url":"https://api.github.com/repos/courte/Ospreydit/contributors","subscribers_url":"https://api.github.com/repos/courte/Ospreydit/subscribers","subscription_url":"https://api.github.com/repos/courte/Ospreydit/subscription","commits_url":"https://api.github.com/repos/courte/Ospreydit/commits{/sha}","git_commits_url":"https://api.github.com/repos/courte/Ospreydit/git/commits{/sha}","comments_url":"https://api.github.com/repos/courte/Ospreydit/comments{/number}","issue_comment_url":"https://api.github.com/repos/courte/Ospreydit/issues/comments/{number}","contents_url":"https://api.github.com/repos/courte/Ospreydit/contents/{+path}","compare_url":"https://api.github.com/repos/courte/Ospreydit/compare/{base}...{head}","merges_url":"https://api.github.com/repos/courte/Ospreydit/merges","archive_url":"https://api.github.com/repos/courte/Ospreydit/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/courte/Ospreydit/downloads","issues_url":"https://api.github.com/repos/courte/Ospreydit/issues{/number}","pulls_url":"https://api.github.com/repos/courte/Ospreydit/pulls{/number}","milestones_url":"https://api.github.com/repos/courte/Ospreydit/milestones{/number}","notifications_url":"https://api.github.com/repos/courte/Ospreydit/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/courte/Ospreydit/labels{/name}","releases_url":"https://api.github.com/repos/courte/Ospreydit/releases{/id}","created_at":"2014-10-27T20:36:49Z","updated_at":"2014-10-27T19:41:32Z","pushed_at":"2014-10-27T19:41:32Z","git_url":"git://github.com/courte/Ospreydit.git","ssh_url":"git@github.com:courte/Ospreydit.git","clone_url":"https://github.com/courte/Ospreydit.git","svn_url":"https://github.com/courte/Ospreydit","homepage":null,"size":72,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":1.0},{"id":24691649,"name":"curriculum","full_name":"courte/curriculum","owner":{"login":"courte","id":2766324,"avatar_url":"https://avatars.githubusercontent.com/u/2766324?v=3","gravatar_id":"","url":"https://api.github.com/users/courte","html_url":"https://github.com/courte","followers_url":"https://api.github.com/users/courte/followers","following_url":"https://api.github.com/users/courte/following{/other_user}","gists_url":"https://api.github.com/users/courte/gists{/gist_id}","starred_url":"https://api.github.com/users/courte/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/courte/subscriptions","organizations_url":"https://api.github.com/users/courte/orgs","repos_url":"https://api.github.com/users/courte/repos","events_url":"https://api.github.com/users/courte/events{/privacy}","received_events_url":"https://api.github.com/users/courte/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/courte/curriculum","description":"","fork":true,"url":"https://api.github.com/repos/courte/curriculum","forks_url":"https://api.github.com/repos/courte/curriculum/forks","keys_url":"https://api.github.com/repos/courte/curriculum/keys{/key_id}","collaborators_url":"https://api.github.com/repos/courte/curriculum/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/courte/curriculum/teams","hooks_url":"https://api.github.com/repos/courte/curriculum/hooks","issue_events_url":"https://api.github.com/repos/courte/curriculum/issues/events{/number}","events_url":"https://api.github.com/repos/courte/curriculum/events","assignees_url":"https://api.github.com/repos/courte/curriculum/assignees{/user}","branches_url":"https://api.github.com/repos/courte/curriculum/branches{/branch}","tags_url":"https://api.github.com/repos/courte/curriculum/tags","blobs_url":"https://api.github.com/repos/courte/curriculum/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/courte/curriculum/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/courte/curriculum/git/refs{/sha}","trees_url":"https://api.github.com/repos/courte/curriculum/git/trees{/sha}","statuses_url":"https://api.github.com/repos/courte/curriculum/statuses/{sha}","languages_url":"https://api.github.com/repos/courte/curriculum/languages","stargazers_url":"https://api.github.com/repos/courte/curriculum/stargazers","contributors_url":"https://api.github.com/repos/courte/curriculum/contributors","subscribers_url":"https://api.github.com/repos/courte/curriculum/subscribers","subscription_url":"https://api.github.com/repos/courte/curriculum/subscription","commits_url":"https://api.github.com/repos/courte/curriculum/commits{/sha}","git_commits_url":"https://api.github.com/repos/courte/curriculum/git/commits{/sha}","comments_url":"https://api.github.com/repos/courte/curriculum/comments{/number}","issue_comment_url":"https://api.github.com/repos/courte/curriculum/issues/comments/{number}","contents_url":"https://api.github.com/repos/courte/curriculum/contents/{+path}","compare_url":"https://api.github.com/repos/courte/curriculum/compare/{base}...{head}","merges_url":"https://api.github.com/repos/courte/curriculum/merges","archive_url":"https://api.github.com/repos/courte/curriculum/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/courte/curriculum/downloads","issues_url":"https://api.github.com/repos/courte/curriculum/issues{/number}","pulls_url":"https://api.github.com/repos/courte/curriculum/pulls{/number}","milestones_url":"https://api.github.com/repos/courte/curriculum/milestones{/number}","notifications_url":"https://api.github.com/repos/courte/curriculum/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/courte/curriculum/labels{/name}","releases_url":"https://api.github.com/repos/courte/curriculum/releases{/id}","created_at":"2014-10-01T19:11:34Z","updated_at":"2014-10-01T12:08:01Z","pushed_at":"2014-11-06T03:03:31Z","git_url":"git://github.com/courte/curriculum.git","ssh_url":"git@github.com:courte/curriculum.git","clone_url":"https://github.com/courte/curriculum.git","svn_url":"https://github.com/courte/curriculum","homepage":null,"size":138,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":0,"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","score":1.0}]}'
     http_version: '1.1'
-  recorded_at: Fri, 23 Jan 2015 23:27:58 GMT
+  recorded_at: Sat, 24 Jan 2015 03:55:07 GMT
 recorded_with: VCR 2.9.3

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -4,44 +4,50 @@ describe EventRegistration do
   it { should belong_to(:event) }
   it { should belong_to(:user) }
 
-  describe "#github_api_args" do
+  describe "GitHub service object interactions" do
+    let(:er) { create(:er_for_october) }
 
-    context "without github auth" do
-      it "returns nil" do
-        er = create(:event_registration)
-        expect(er.github_api_args).to be_nil
+    describe "#github_api_args" do
+
+      context "without github auth" do
+        it "returns nil" do
+          er = create(:event_registration)
+          expect(er.github_api_args).to be_nil
+        end
       end
-    end
 
-    context "with github auth" do
-      it "returns args", github_api: true do
-        er = create(:er_for_october)
+      context "with github auth" do
+        it "returns args", github_api: true do
 
-        VCR.use_cassette("courte_user") do
-          expect(er.github_api_args).to eq(
-            user: "courte",
-            day_begin: Time.new(2014, 10, 01),
-            day_end: Time.new(2014, 10, 31)
-          )
+          VCR.use_cassette("courte_user") do
+            expect(er.github_api_args).to eq(
+              user: "courte",
+              day_begin: Time.new(2014, 10, 01),
+              day_end: Time.new(2014, 10, 31)
+            )
+          end
         end
       end
     end
-  end
 
-  describe "#stats" do
-    context "without github auth" do
-      it "returns nil" do
-        er = create(:event_registration)
-        expect(er.stats).to be_nil
+    describe "#fetch_github_stats" do
+      context "without github auth" do
+        it "returns nil" do
+          er = create(:event_registration)
+          expect(er.fetch_github_stats).to be_nil
+        end
       end
-    end
 
-    context "with github auth" do
-      it "returns metrics in a hash", github_api: true do
-        er = create(:er_for_october)
-
-        VCR.use_cassette("courte_er_stats") do
-          expect(er.stats).to eq(prs: 1, issues: 0, commits: 1, forks: 2)
+      context "with github auth" do
+        it "returns GitHub stats", github_api: true do
+          VCR.use_cassette("courte_oct_stats") do
+            expect(er.fetch_github_stats).to eq(
+              pull_requests: 1,
+              commits: 1,
+              issues: 0,
+              forks: 2
+            )
+          end
         end
       end
     end

--- a/spec/models/featured_project_spec.rb
+++ b/spec/models/featured_project_spec.rb
@@ -23,5 +23,16 @@ describe FeaturedProject do
         day_end: Time.new(2014, 10, 31)
       )
     end
+
+    it "returns GitHub stats", github_api: true do
+      VCR.use_cassette("codemontage_oct_stats") do
+        expect(featured_project.fetch_github_stats).to eq(
+          pull_requests: 2,
+          commits: 3,
+          issues: 3,
+          forks: 0
+        )
+      end
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -36,13 +36,48 @@ describe Project do
     end
   end
 
-  describe "#github_api_args" do
-    it "returns basic arguments for the GitHub service object" do
-      project = create(:project)
-      args = [:org_repo, :repo, :day_begin, :day_end]
+  describe "GitHub API interaction" do
+    let(:project) { build(:project) }
+    let(:args) do
+      project.github_api_args.merge!(day_begin: Time.new(2014, 10, 01),
+                                     day_end: Time.new(2014, 10, 31))
+    end
 
-      args.each do |arg|
-        expect(project.github_api_args.has_key?(arg)).to be_true
+    describe "#github_api_args" do
+      it "returns basic arguments for the GitHub service object" do
+        args = [:org_repo, :repo, :day_begin, :day_end]
+
+        args.each do |arg|
+          expect(project.github_api_args.has_key?(arg)).to be_true
+        end
+      end
+    end
+
+    it "finds pull requests", github_api: true do
+      VCR.use_cassette("codemontage_oct_prs") do
+        prs = project.github_pull_requests(args)
+        expect(prs.count).to eq(2)
+      end
+    end
+
+    it "finds commits", github_api: true do
+      VCR.use_cassette("codemontage_oct_commits") do
+        commits = project.github_commits(args)
+        expect(commits.count).to eq(3)
+      end
+    end
+
+    it "finds issues by repo", github_api: true do
+      VCR.use_cassette("codemontage_oct_issues") do
+        issues = project.github_issues(args)
+        expect(issues.count).to eq(3)
+      end
+    end
+
+    it "finds forks by repo", github_api: true do
+      VCR.use_cassette("codemontage_oct_forks") do
+        forks = project.github_forks(args)
+        expect(forks.count).to eq(0)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,23 +28,82 @@ describe User do
     it { should_not be_valid }
   end
 
-  describe "#github_api_args" do
+  describe "GitHub API interaction" do
+    let(:user) { create(:user_with_github) }
+    let(:args) do
+      VCR.use_cassette("courte_user") do
+        user.github_api_args.merge!(day_begin: Time.new(2014, 10, 01),
+                                    day_end: Time.new(2014, 10, 31))
+      end
+    end
+
+    describe "#github_api_args" do
+      context "without github auth" do
+        it "returns nil" do
+          user = create(:user)
+          expect(user.github_api_args).to be_nil
+        end
+      end
+
+      context "with github auth" do
+        it "returns args", github_api: true do
+          args = [:user, :day_begin, :day_end]
+
+          VCR.use_cassette("courte_user") do
+            args.each do |arg|
+              expect(user.github_api_args.has_key?(arg)).to be_true
+            end
+          end
+        end
+      end
+    end
+
     context "without github auth" do
-      it "returns nil" do
-        user = create(:user)
-        expect(user.github_api_args).to be_nil
+      let(:user) { create(:user) }
+
+      it "returns nil for pull requests" do
+        expect(user.github_pull_requests).to be_nil
+      end
+
+      it "returns nil for commits" do
+        expect(user.github_commits).to be_nil
+      end
+
+      it "returns nil for issues" do
+        expect(user.github_issues).to be_nil
+      end
+
+      it "returns nil for forks" do
+        expect(user.github_forks).to be_nil
       end
     end
 
     context "with github auth" do
-      it "returns args", github_api: true do
-        user = create(:user_with_github)
-        args = [:user, :day_begin, :day_end]
+      it "finds the user's pull requests", github_api: true do
+        VCR.use_cassette("courte_oct_prs") do
+          prs = user.github_pull_requests(args)
+          expect(prs.count).to eq(1)
+        end
+      end
 
-        VCR.use_cassette("courte_user") do
-          args.each do |arg|
-            expect(user.github_api_args.has_key?(arg)).to be_true
-          end
+      it "finds the user's commits", github_api: true do
+        VCR.use_cassette("courte_oct_commits") do
+          commits = user.github_commits(args)
+          expect(commits.count).to eq(1)
+        end
+      end
+
+      it "finds the user's issues", github_api: true do
+        VCR.use_cassette("courte_oct_issues") do
+          issues = user.github_issues(args)
+          expect(issues.count).to eq(0)
+        end
+      end
+
+      it "finds the user's forks", github_api: true do
+        VCR.use_cassette("courte_oct_forks") do
+          forks = user.github_forks(args)
+          expect(forks.count).to eq(2)
         end
       end
     end


### PR DESCRIPTION
Last part and parcel of #311's refactor, now with all the event-related GitHub participation stats you'd been waiting for: `users`, `projects`, `event_registrations`, `featured_projects`, and `events` can all return their GitHub participation metrics as hashes.