### PR TITLE
Add helpful project links

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -11,7 +11,9 @@ ActiveAdmin.register Project do
     column :github_repo
     column :description
     column :install_url do |proj|
-      link_to proj.install_url, proj.install_url, target: "blank" if proj.install_url?
+      if proj.install_url?
+        link_to proj.install_url, proj.install_url, target: "blank"
+      end
     end
     column :help_url do |proj|
       link_to proj.help_url, proj.help_url, target: "blank" if proj.help_url?
@@ -74,9 +76,7 @@ ActiveAdmin.register Project do
         end
       end
       row :help_url do |proj|
-        if proj.help_url?
-          link_to proj.help_url, proj.help_url, target: "blank"
-        end
+        link_to proj.help_url, proj.help_url, target: "blank" if proj.help_url?
       end
       row :description
       row 'Causes' do ad.cause_list end

--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -10,6 +10,12 @@ ActiveAdmin.register Project do
     end
     column :github_repo
     column :description
+    column :install_url do |proj|
+      link_to proj.install_url, proj.install_url, target: "blank" if proj.install_url?
+    end
+    column :help_url do |proj|
+      link_to proj.help_url, proj.help_url, target: "blank" if proj.help_url?
+    end
     column 'Causes', :cause_list
     column 'Technologies', :technology_list
     column :notes
@@ -25,6 +31,9 @@ ActiveAdmin.register Project do
   filter :name
   filter :github_repo
   filter :description
+  filter :url
+  filter :install_url
+  filter :help_url
   filter :notes
   filter :created_at
   filter :updated_at
@@ -38,6 +47,8 @@ ActiveAdmin.register Project do
       f.input :name
       f.input :github_repo
       f.input :url
+      f.input :install_url
+      f.input :help_url
       f.input :description
       f.input :cause_list, label: 'Causes'
       f.input :technology_list, label: 'Technologies'
@@ -56,6 +67,12 @@ ActiveAdmin.register Project do
       row :github_repo
       row :url do |proj|
         link_to proj.url, proj.url, target: 'blank' if proj.url?
+      end
+      row :install_url do |proj|
+        link_to proj.install_url, proj.install_url, target: "blank" if proj.install_url?
+      end
+      row :help_url do |proj|
+        link_to proj.help_url, proj.help_url, target: "blank" if proj.help_url?
       end
       row :description
       row 'Causes' do ad.cause_list end

--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -69,10 +69,14 @@ ActiveAdmin.register Project do
         link_to proj.url, proj.url, target: 'blank' if proj.url?
       end
       row :install_url do |proj|
-        link_to proj.install_url, proj.install_url, target: "blank" if proj.install_url?
+        if proj.install_url?
+          link_to proj.install_url, proj.install_url, target: "blank"
+        end
       end
       row :help_url do |proj|
-        link_to proj.help_url, proj.help_url, target: "blank" if proj.help_url?
+        if proj.help_url?
+          link_to proj.help_url, proj.help_url, target: "blank"
+        end
       end
       row :description
       row 'Causes' do ad.cause_list end

--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -15,3 +15,19 @@ h5 span.favorite {
     padding: 4px;
   }
 }
+
+#project_links.one-line ul {
+  padding-bottom: 3%;
+
+  li {
+    float: left;
+    padding: 0 2%;
+    border-left: 2px solid $cmTeal;
+
+    &:first-child { border: 0 none; }
+  }
+}
+
+#summary {
+  clear: both;
+}

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,9 @@ class Project < ActiveRecord::Base
   acts_as_ordered_taggable
   acts_as_ordered_taggable_on :technologies, :causes
 
-  attr_accessible :organization_id, :name, :url, :github_repo, :description, :notes, :cause_list, :technology_list, :is_active, :is_approved
+  attr_accessible :cause_list, :description, :github_repo, :help_url,
+                  :install_url, :is_active, :is_approved, :name, :notes,
+                  :organization_id, :technology_list, :url
   validates_presence_of :name, :github_repo
 
   has_many :favorite_projects

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -19,9 +19,10 @@
 
   <div class="project_links large-2 columns">
     <ul class="no-bullet">
-      <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' unless !project.github_url.present? %></li>
-      <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' unless !project.tasks_url.present? %></li>
-      <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + "News", twitter_url(project.organization.twitter), :target => '_blank' unless !project.organization.twitter.present? %></li>
+      <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + "Code", project.github_url, :target => '_blank' if project.github_url.present? %></li>
+      <li><%= link_to '<i class="fi-wrench"></i> '.html_safe + "Install", project.install_url, :target => '_blank' if project.install_url.present? %></li>
+      <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + "Tasks", project.tasks_url, :target => '_blank' if project.tasks_url.present? %></li>
+      <li><%= link_to '<i class="fi-comments"></i> '.html_safe + "Help", project.help_url, :target => '_blank' if project.help_url.present? %></li>
     </ul>
   </div>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -30,7 +30,7 @@
       <% if @related_projects.exists? %>
         <div id="related_projects">
           <h5>Related Projects</h5>
-    
+
           <% @related_projects.each do |project| %>
             <h6><%= link_to project.name, project_path(project) %></h6>
           <% end %>
@@ -40,12 +40,12 @@
 
     <div class="large-4 columns">
       <%= link_to image_tag(find_logo(@project.organization), :alt => @project.organization.name), @project.organization.url, :target => '_blank' if find_logo?(@project.organization) %>
-      
+
       <div id="project_causes">
         <h5>Causes</h5>
         <%= project_tags_link_list @project, 'causes' %>
       </div>
-      
+
       <div id="project_technologies">
         <h5>Technologies</h5>
         <%= project_tags_link_list @project, 'technologies' %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,9 +5,11 @@
       <h4><%= @project.name %></h4>
       <div id="links">
         <ul class="no-bullet">
-          <li><%= link_to '<i class="fi-web"></i> '.html_safe + display_url(@project.url), @project.url, :target => '_blank' unless !@project.url.present? %></li>
-          <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + @project.github_display + " Code", @project.github_url, :target => '_blank' unless !@project.github_url.present? %></li>
-          <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + @project.name + " Open Tasks", @project.tasks_url, :target => '_blank' unless !@project.tasks_url.present? %></li>
+          <li><%= link_to '<i class="fi-web"></i> '.html_safe + display_url(@project.url), @project.url, :target => '_blank'if @project.url.present? %></li>
+          <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + @project.github_display + " Code", @project.github_url, :target => '_blank' if @project.github_url.present? %></li>
+          <li><%= link_to '<i class="fi-wrench"></i> '.html_safe + "Install " + @project.name, @project.install_url, :target => '_blank' if @project.install_url.present? %></li>
+          <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + @project.name + " Open Tasks", @project.tasks_url, :target => '_blank' if @project.tasks_url.present? %></li>
+          <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + @project.name + " News", twitter_url(@project.organization.twitter), :target => '_blank' if @project.organization.twitter.present? %></li>
         </ul>
       </div>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,11 +5,21 @@
       <h4><%= @project.name %></h4>
       <div id="project_links" class="one-line">
         <ul class="no-bullet">
-          <li><%= link_to '<i class="fi-web"></i> '.html_safe + display_url(@project.url), @project.url, :target => '_blank'if @project.url.present? %></li>
-          <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + @project.github_display + " Code", @project.github_url, :target => '_blank' if @project.github_url.present? %></li>
-          <li><%= link_to '<i class="fi-wrench"></i> '.html_safe + "Install " + @project.name, @project.install_url, :target => '_blank' if @project.install_url.present? %></li>
-          <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + @project.name + " Open Tasks", @project.tasks_url, :target => '_blank' if @project.tasks_url.present? %></li>
-          <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + @project.name + " News", twitter_url(@project.organization.twitter), :target => '_blank' if @project.organization.twitter.present? %></li>
+          <% if @project.url.present? %>
+            <li><%= link_to '<i class="fi-web"></i> '.html_safe + " Website", @project.url, :target => '_blank' %></li>
+          <% end %>
+          <% if @project.github_url.present? %>
+            <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + " Code", @project.github_url, :target => '_blank' %></li>
+          <% end %>
+          <% if @project.install_url.present? %>
+            <li><%= link_to '<i class="fi-wrench"></i> '.html_safe + " Install", @project.install_url, :target => '_blank' %></li>
+          <% end %>
+          <% if @project.tasks_url.present? %>
+            <li><%= link_to '<i class="fi-page-edit"></i> '.html_safe + " Tasks", @project.tasks_url, :target => '_blank' %></li>
+          <% end %>
+          <% if @project.organization.twitter.present? %>
+            <li><%= link_to '<i class="fi-social-twitter"></i> '.html_safe + " News", twitter_url(@project.organization.twitter), :target => '_blank' %></li>
+          <% end %>
         </ul>
       </div>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -3,7 +3,7 @@
     <div class="large-8 columns">
       <h4><%= link_to @project.organization.name, organization_path(@project.organization) %></h4>
       <h4><%= @project.name %></h4>
-      <div id="links">
+      <div id="project_links" class="one-line">
         <ul class="no-bullet">
           <li><%= link_to '<i class="fi-web"></i> '.html_safe + display_url(@project.url), @project.url, :target => '_blank'if @project.url.present? %></li>
           <li><%= link_to '<i class="fi-social-github"></i> '.html_safe + @project.github_display + " Code", @project.github_url, :target => '_blank' if @project.github_url.present? %></li>

--- a/db/migrate/20150127012233_add_install_url_and_help_url_to_projects.rb
+++ b/db/migrate/20150127012233_add_install_url_and_help_url_to_projects.rb
@@ -1,0 +1,6 @@
+class AddInstallUrlAndHelpUrlToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :install_url, :string
+    add_column :projects, :help_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150112145730) do
+ActiveRecord::Schema.define(:version => 20150127012233) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -154,6 +154,8 @@ ActiveRecord::Schema.define(:version => 20150112145730) do
     t.string   "slug"
     t.boolean  "is_approved",     :default => false, :null => false
     t.string   "url"
+    t.string   "install_url"
+    t.string   "help_url"
   end
 
   add_index "projects", ["slug"], :name => "index_projects_on_slug", :unique => true


### PR DESCRIPTION
This update gives projects the option to have links to installation directions and/or a help area (chat room, email, etc). It adds these links to the admin areas, as well as the projects partial.

The install link has also been added to the project show page and the news/twitter link has been moved there as well. I think 4 links in a column is the upward limit of these links not looking crowded and distracted, so the help url has not been added to the project show page currently.

Take a peek!

*Projects partial on the index page*
![screenshot 2015-01-27 10 14
 01](https://cloud.githubusercontent.com/assets/2766324/5921311/10e5c452-a611-11e4-9e64-e08766a1eb3f.png)

*Install & help urls in admin areas (edit, show & index)*
![screenshot 2015-01-27 10 14 14](https://cloud.githubusercontent.com/assets/2766324/5921316/10ef02b0-a611-11e4-9631-4a47ac5c2030.png)
![screenshot 2015-01-27 10 14 33](https://cloud.githubusercontent.com/assets/2766324/5921313/10e9c52a-a611-11e4-8f51-43e54d4c9017.png)
![screenshot 2015-01-27 10 14 46](https://cloud.githubusercontent.com/assets/2766324/5921312/10e62410-a611-11e4-9796-5819b85d3e77.png)

*Install url and news/twitter link on project show page*
![screenshot 2015-01-27 10 14 58](https://cloud.githubusercontent.com/assets/2766324/5921314/10ea1df4-a611-11e4-8c06-66e91a3931bc.png)

*New links included with a featured project on an event show page*
![screenshot 2015-01-27 10 40 36](https://cloud.githubusercontent.com/assets/2766324/5921315/10eb05ac-a611-11e4-8670-df56dea73087.png)
