### PR TITLE
Add on-platform favorites of featured projects to Event stats

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -59,6 +59,20 @@ class Event < ActiveRecord::Base
     stats
   end
 
+  def all_favorites_stats
+    stats = {}
+
+    all_favorites = FavoriteProject.created_between(start_date, end_date)
+    stats[:total] = all_favorites.count
+
+    stats[:by_project] = all_favorites.group_by { |fave| fave.project.name }
+    stats[:by_project].each do |project_name, project_faves|
+      stats[:by_project][project_name] = project_faves.count
+    end
+
+    stats
+  end
+
   def github_api_args
     { day_begin: start_date,
       day_end:   end_date }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -108,7 +108,8 @@ class Event < ActiveRecord::Base
   def fetch_engagement_stats
     stats = {}
 
-    stats[:favorites] = featured_projects_favorites_stats
+    stats[:all_favorites] = all_favorites_stats
+    stats[:featured_favorites] = featured_projects_favorites_stats
     stats[:by_attendee] = attendee_github_stats
     stats[:by_project] = project_github_stats
     stats[:total] = total_github_stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,20 +42,6 @@ class Event < ActiveRecord::Base
     @logo_delete || '0'
   end
 
-  def featured_projects_favorites_stats
-    stats = { by_project: {} }
-
-    all_favorites = all_favorites_stats[:by_project]
-
-    projects.each do |project|
-      stats[:by_project][project.name] = all_favorites[project.name]
-    end
-
-    stats[:total] = stats[:by_project].values.reduce(:+)
-
-    stats
-  end
-
   def all_favorites_stats
     stats = {}
 
@@ -66,6 +52,20 @@ class Event < ActiveRecord::Base
     stats[:by_project].each do |project_name, project_faves|
       stats[:by_project][project_name] = project_faves.count
     end
+
+    stats
+  end
+
+  def featured_projects_favorites_stats
+    stats = { by_project: {} }
+
+    all_favorites = all_favorites_stats[:by_project]
+
+    projects.each do |project|
+      stats[:by_project][project.name] = all_favorites[project.name]
+    end
+
+    stats[:total] = stats[:by_project].values.reduce(:+)
 
     stats
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,6 +42,23 @@ class Event < ActiveRecord::Base
     @logo_delete || '0'
   end
 
+  def favorited_project_stats
+    stats = {}
+    stats[:by_project] = {}
+
+    projects.each do |project|
+      event_faves = project.favorite_projects.select do |fave|
+        fave.created_at >= start_date && fave.created_at <= end_date
+      end
+
+      stats[:by_project].merge!(project.name => event_faves.count)
+    end
+
+    stats[:total] = stats[:by_project].values.reduce(:+)
+
+    stats
+  end
+
   def github_api_args
     { day_begin: start_date,
       day_end:   end_date }
@@ -77,6 +94,7 @@ class Event < ActiveRecord::Base
   def fetch_github_stats
     stats = {}
 
+    stats[:featured_project_favorites] = favorited_project_stats
     stats[:by_attendee] = attendee_github_stats
     stats[:by_project] = project_github_stats
     stats[:total] = total_github_stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,7 +42,7 @@ class Event < ActiveRecord::Base
     @logo_delete || '0'
   end
 
-  def favorited_project_stats
+  def featured_projects_favorites_stats
     stats = {}
     stats[:by_project] = {}
 
@@ -87,14 +87,14 @@ class Event < ActiveRecord::Base
     stats
   end
 
-  def github_stats
-    @github_stats ||= fetch_github_stats
+  def engagement_stats
+    @engagement_stats ||= fetch_engagement_stats
   end
 
-  def fetch_github_stats
+  def fetch_engagement_stats
     stats = {}
 
-    stats[:featured_project_favorites] = favorited_project_stats
+    stats[:favorites] = featured_projects_favorites_stats
     stats[:by_attendee] = attendee_github_stats
     stats[:by_project] = project_github_stats
     stats[:total] = total_github_stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -43,15 +43,12 @@ class Event < ActiveRecord::Base
   end
 
   def featured_projects_favorites_stats
-    stats = {}
-    stats[:by_project] = {}
+    stats = { by_project: {} }
+
+    all_favorites = all_favorites_stats[:by_project]
 
     projects.each do |project|
-      event_faves = project.favorite_projects.select do |fave|
-        fave.created_at >= start_date && fave.created_at <= end_date
-      end
-
-      stats[:by_project].merge!(project.name => event_faves.count)
+      stats[:by_project][project.name] = all_favorites[project.name]
     end
 
     stats[:total] = stats[:by_project].values.reduce(:+)

--- a/app/models/favorite_project.rb
+++ b/app/models/favorite_project.rb
@@ -3,4 +3,8 @@ class FavoriteProject < ActiveRecord::Base
   belongs_to :user
 
   validates_uniqueness_of :project_id, :scope => :user_id
+
+  def self.created_between(start_date, end_date)
+    where('created_at >= ? AND created_at <= ?', start_date, end_date)
+  end
 end

--- a/app/models/favorite_project.rb
+++ b/app/models/favorite_project.rb
@@ -5,6 +5,6 @@ class FavoriteProject < ActiveRecord::Base
   validates_uniqueness_of :project_id, :scope => :user_id
 
   def self.created_between(start_date, end_date)
-    where('created_at >= ? AND created_at <= ?', start_date, end_date)
+    where("created_at >= ? AND created_at <= ?", start_date, end_date)
   end
 end


### PR DESCRIPTION
Adds a method to `Event` that return the stats on the number of featured projects favorited during the event. It also includes this result in the (now inaccurately-named) `fetch_github_stats` results.

Here's an example call with results at the very bottom:
![screenshot 2015-01-28 11 45 27](https://cloud.githubusercontent.com/assets/2766324/5942085/3d754fba-a6e3-11e4-90c4-4a24a6c77a22.png)
