### PR TITLE
Avoid GitHub rate limit

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -49,7 +49,11 @@ class Event < ActiveRecord::Base
     stats = {}
 
     event_registrations.each do |er|
-      stats.merge!(er.user.email => er.fetch_github_stats)
+      begin
+        stats.merge!(er.user.email => er.fetch_github_stats)
+      rescue
+        next
+      end
     end
 
     stats
@@ -59,7 +63,11 @@ class Event < ActiveRecord::Base
     stats = {}
 
     featured_projects.each do |fp|
-      stats.merge!(fp.project.name => fp.fetch_github_stats)
+      begin
+        stats.merge!(fp.project.name => fp.fetch_github_stats)
+      rescue
+        next
+      end
     end
 
     stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -100,7 +100,7 @@ class Event < ActiveRecord::Base
         end
       end
 
-      sleep(60) # avoid GH search rate limit
+      sleep(60) # avoid GH search rate limit of 20 requests per minute
     end
 
     stats
@@ -118,7 +118,7 @@ class Event < ActiveRecord::Base
         end
       end
 
-      sleep(60) # avoid GH search rate limit
+      sleep(60) # avoid GH search rate limit of 20 requests per minute
     end
 
     stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -46,39 +46,11 @@ class Event < ActiveRecord::Base
   end
 
   def attendee_github_stats
-    stats = {}
-
-    event_registrations.find_in_batches(batch_size: 5) do |er_batch|
-      er_batch.each do |er|
-        begin
-          stats.merge!(er.user.email => er.fetch_github_stats)
-        rescue
-          next
-        end
-      end
-
-      sleep(60) #avoid GH search rate limit
-    end
-
-    stats
+    @attendee_github_stats ||= fetch_attendee_github_stats
   end
 
   def project_github_stats
-    stats = {}
-
-    featured_projects.find_in_batches(batch_size: 5) do |fp_batch|
-      fp_batch.each do |fp|
-        begin
-          stats.merge!(fp.project.name => fp.fetch_github_stats)
-        rescue
-          next
-        end
-      end
-
-      sleep(60)
-    end
-
-    stats
+    @project_github_stats ||= fetch_project_github_stats
   end
 
   def total_github_stats
@@ -96,6 +68,10 @@ class Event < ActiveRecord::Base
     stats
   end
 
+  def github_stats
+    @github_stats ||= fetch_github_stats
+  end
+
   def fetch_github_stats
     stats = {}
 
@@ -110,5 +86,41 @@ class Event < ActiveRecord::Base
 
   def delete_logo
     logo.clear if logo_delete == '1'
+  end
+
+  def fetch_attendee_github_stats
+    stats = {}
+
+    event_registrations.find_in_batches(batch_size: 5) do |er_batch|
+      er_batch.each do |er|
+        begin
+          stats.merge!(er.user.email => er.fetch_github_stats)
+        rescue
+          next
+        end
+      end
+
+      sleep(60) #avoid GH search rate limit
+    end
+
+    stats
+  end
+
+  def fetch_project_github_stats
+    stats = {}
+
+    featured_projects.find_in_batches(batch_size: 5) do |fp_batch|
+      fp_batch.each do |fp|
+        begin
+          stats.merge!(fp.project.name => fp.fetch_github_stats)
+        rescue
+          next
+        end
+      end
+
+      sleep(60)
+    end
+
+    stats
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -100,7 +100,7 @@ class Event < ActiveRecord::Base
         end
       end
 
-      sleep(60) #avoid GH search rate limit
+      sleep(60) # avoid GH search rate limit
     end
 
     stats
@@ -118,7 +118,7 @@ class Event < ActiveRecord::Base
         end
       end
 
-      sleep(60)
+      sleep(60) # avoid GH search rate limit
     end
 
     stats

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -48,12 +48,16 @@ class Event < ActiveRecord::Base
   def attendee_github_stats
     stats = {}
 
-    event_registrations.each do |er|
-      begin
-        stats.merge!(er.user.email => er.fetch_github_stats)
-      rescue
-        next
+    event_registrations.find_in_batches(batch_size: 5) do |er_batch|
+      er_batch.each do |er|
+        begin
+          stats.merge!(er.user.email => er.fetch_github_stats)
+        rescue
+          next
+        end
       end
+
+      sleep(60) #avoid GH search rate limit
     end
 
     stats
@@ -62,12 +66,16 @@ class Event < ActiveRecord::Base
   def project_github_stats
     stats = {}
 
-    featured_projects.each do |fp|
-      begin
-        stats.merge!(fp.project.name => fp.fetch_github_stats)
-      rescue
-        next
+    featured_projects.find_in_batches(batch_size: 5) do |fp_batch|
+      fp_batch.each do |fp|
+        begin
+          stats.merge!(fp.project.name => fp.fetch_github_stats)
+        rescue
+          next
+        end
       end
+
+      sleep(60)
     end
 
     stats


### PR DESCRIPTION
This PR fixes immediate GitHub stats-related problems. It includes:
- basic error-handling for pesky failing GitHub search queries
- batch GitHub stats processing of event-related resources to avoid GitHub API search rate limit
- memoized stats (`attendee_github_stats`, `project_github_stats`, `github_stats`) to prevent multiple time-draining pulls to the API in a single session
