### PR TITLE
Modify the events page to show the rsvp before 'Join Us'

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,6 @@
       <div class="large-10 columns large-centered text-center">
         <%= image_tag @event.logo, :alt => @event.name %>
       </div>
-      <div>
-        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
-      </div> 
       
       <div id="event_rsvp_top" class="row">
         <div class="large-10 columns large-centered text-center">
@@ -20,6 +17,10 @@
           <% end %>
         </div>
       </div>
+
+      <div>
+        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
+      </div> 
 
       <div class="large-10 columns large-centered text-center">
         <h1><%= @event.name %></h1>


### PR DESCRIPTION
Issue #324 Modify the rsvp button so that it is positioned about Join us event phrase.