### PR TITLE
Add Code of Conduct blurb to Events show page

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,7 +6,7 @@
       <div class="large-10 columns large-centered text-center">
         <%= image_tag @event.logo, :alt => @event.name %>
       </div>
-      
+
       <div id="event_rsvp_top" class="row">
         <div class="large-10 columns large-centered text-center">
           <%= %>
@@ -20,7 +20,7 @@
 
       <div>
         <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
-      </div> 
+      </div>
 
       <div class="large-10 columns large-centered text-center">
         <h1><%= @event.name %></h1>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,6 +29,21 @@
         </div>
       </div>
 
+      <div id="event_code_of_conduct" class="large-10 columns large-centered">
+        <h4>Code of Conduct</h4>
+        <p>
+          This event is utilizing the <%= link_to "CodeMontage Code of Conduct", "/code_of_conduct" %>. <strong>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact an event organizer immediately.</strong>
+
+          <ul class="no-bullet">
+          <% if @event.lead_organizer.present? %>
+            <li><strong>Lead Organizer:</strong> <%= @event.lead_organizer %>, <a href="mailto:<%= @event.lead_email %>"><%= @event.lead_email %></a></li>
+          <% end %>
+          <% if @event.organizer.present? %>
+            <li><strong>Organizer:</strong> <%= @event.organizer %>, <a href="mailto:<%= @event.organizer_email %>"><%= @event.organizer_email %></a></li>
+          <% end %>
+        </p>
+      </div>
+
       <div id="event_featured_projects" class="large-10 columns large-centered">
         <% if @featured_projects.present? %>
           <h4>Featured Projects</h4>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -69,9 +69,9 @@
       </div>
     <% end %>
 
-    <div id="mlkd_vid" class="row">
+    <div id="related_events" class="row">
       <div class="large-10 columns large-centered">
-        <h4>Similar Events</h4>
+        <h4>Related Events</h4>
 
         <div id="mlkd_video" class="flex-video">
           <iframe src="//player.vimeo.com/video/85846616?byline=0&amp;color=ffffff" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>


### PR DESCRIPTION
This PR:
- Adds a blurb from the Code of Conduct to the Events show page (#262)
- Fixes #325 
- Includes screenshots :point_down: :point_down: 

*Code of Conduct blurb*
![screenshot 2015-02-09 16 52 33](https://cloud.githubusercontent.com/assets/2766324/6116643/80593e20-b07c-11e4-81cd-de55c4bbc9fe.png)

===
*Related Events section*
![screenshot 2015-02-09 16 54 07](https://cloud.githubusercontent.com/assets/2766324/6116644/805be396-b07c-11e4-9616-f233696b8b71.png)