### PR TITLE
Add timezone info to event time inputs

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -27,8 +27,12 @@ ActiveAdmin.register Event do
       f.input :lead_email, label: 'Lead organizer email'
       f.input :organizer
       f.input :organizer_email
-      f.input :start_date, hint: "Be sure to input the start date in UTC/Greenwich Mean Time."
-      f.input :end_date, hint: "Be sure to input the end date in UTC/Greenwich Mean Time."
+      f.input :start_date,
+              hint: "Be sure to input the start date in \
+                    UTC/Greenwich Mean Time."
+      f.input :end_date,
+              hint: "Be sure to input the end date in \
+                    UTC/Greenwich Mean Time."
       f.input :location
       f.input :teaser
       f.input :description

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -27,8 +27,8 @@ ActiveAdmin.register Event do
       f.input :lead_email, label: 'Lead organizer email'
       f.input :organizer
       f.input :organizer_email
-      f.input :start_date
-      f.input :end_date
+      f.input :start_date, hint: "Be sure to input the start date in UTC/Greenwich Mean Time."
+      f.input :end_date, hint: "Be sure to input the end date in UTC/Greenwich Mean Time."
       f.input :location
       f.input :teaser
       f.input :description


### PR DESCRIPTION
This PR adds hints that encourage administrative users to input event start & end times for the UTC time zone. Because check-in prompting is now dependent on accurate start and end times, this has become important.

![screenshot 2015-02-09 17 24 20](https://www.evernote.com/shard/s207/sh/d453b8cd-566f-481c-80a9-3fa6cb81a353/98348131da2e52833a952d18f82ae1b8/res/562db021-cada-45ca-a903-18aaca3d8ae8/skitch.png)