### PR TITLE
Add basic schedules to events

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -43,6 +43,7 @@ ActiveAdmin.register Event do
         f.input :logo, as: :file
       end
       f.input :is_public, label: "Public?", as: :boolean
+      f.input :schedule
       f.input :chat_url
       f.input :map_url
       f.input :schedule_url
@@ -82,6 +83,7 @@ ActiveAdmin.register Event do
         end
       end
       row "Public?" do ad.is_public end
+      row :schedule
       row :chat_url do link_to ad.chat_url, ad.chat_url if ad.chat_url.present? end
       row :map_url do link_to ad.map_url, ad.map_url if ad.map_url.present? end
       row :schedule_url do link_to ad.schedule_url, ad.schedule_url if ad.schedule_url.present? end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,7 @@ class Event < ActiveRecord::Base
   has_many :projects, through: :featured_projects
 
   attr_accessible :name, :short_code, :start_date, :end_date, :teaser, :description, :notes
-  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email
+  attr_accessible :logo, :logo_delete, :lead_organizer, :lead_email, :schedule
   attr_accessible :organizer, :organizer_email, :location, :is_public
   attr_accessible :chat_url, :map_url, :schedule_url, :hashtag, :eventbrite_url
   attr_accessible :featured_projects_attributes

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,6 +29,17 @@
         </div>
       </div>
 
+      <% if @event.schedule.present? %>
+        <div id="event_schedule" class="large-10 columns large-centered">
+          <h4>Schedule</h4>
+          <div class="large-10 columns large-centered">
+            <ul>
+              <%=raw @event.schedule %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+
       <div id="event_code_of_conduct" class="large-10 columns large-centered">
         <h4>Code of Conduct</h4>
         <p>

--- a/db/migrate/20150209221313_add_schedule_to_events.rb
+++ b/db/migrate/20150209221313_add_schedule_to_events.rb
@@ -1,0 +1,5 @@
+class AddScheduleToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :schedule, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150127012233) do
+ActiveRecord::Schema.define(:version => 20150209221313) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(:version => 20150127012233) do
     t.string   "organizer_email"
     t.string   "location"
     t.boolean  "is_public",         :default => false, :null => false
+    t.text     "schedule"
   end
 
   add_index "events", ["short_code"], :name => "index_events_on_short_code", :unique => true


### PR DESCRIPTION
- Adds schedule to events on database, model, admin, and front end levels
- Shows schedule as raw HTML list items (I figured we could work out the formatting of this a little later.)
- Sets schedule to be a smaller width than most of the Event show page

I would love to have this & the description section to be markdown one day, but alas. Let's :rocket: it.

*Editing a schedule*
![screenshot 2015-02-09 23 26 10](https://cloud.githubusercontent.com/assets/2766324/6121551/84bc61ae-b0b3-11e4-9945-6fae51957560.png)

*Look at it go!*
![screenshot 2015-02-09 23 25 49](https://cloud.githubusercontent.com/assets/2766324/6121550/84bb9e5e-b0b3-11e4-8751-9a3df2dfecd0.png)

*LOOK AT IT GO.*
![screenshot 2015-02-09 23 26 28](https://cloud.githubusercontent.com/assets/2766324/6121548/84bb474c-b0b3-11e4-94ab-67f475556ced.png)