### PR TITLE
Add User-Engaged Projects

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ActiveRecord::Base
   has_one :profile, class_name: 'UserProfile'
   delegate :gravatar_email, :headline, :is_coder, :name, :represents_org, :represents_team, :cause_list, :technology_list, :email_news, :email_training, to: :profile
 
+  has_many :user_engaged_projects
+
   validates_presence_of :password, on: :create # will only run on account creation
 
   validates_presence_of :email    # will run in all validation contexts

--- a/app/models/user_engaged_project.rb
+++ b/app/models/user_engaged_project.rb
@@ -1,0 +1,6 @@
+class UserEngagedProject < ActiveRecord::Base
+  belongs_to :user
+
+  attr_accessible :engagement_type, :github_created_at, :project_github_url,
+                  :user_id
+end

--- a/db/migrate/20150211210612_create_user_engaged_projects.rb
+++ b/db/migrate/20150211210612_create_user_engaged_projects.rb
@@ -1,0 +1,14 @@
+class CreateUserEngagedProjects < ActiveRecord::Migration
+  def change
+    create_table :user_engaged_projects do |t|
+      t.string      :project_github_url, null: false
+      t.string      :engagement_type,    null: false
+      t.datetime    :github_created_at,  null: false
+      t.references  :user,               null: false
+      t.timestamps
+    end
+
+    add_index :user_engaged_projects, :user_id
+    add_index :user_engaged_projects, :project_github_url
+  end
+end

--- a/db/migrate/20150211210612_create_user_engaged_projects.rb
+++ b/db/migrate/20150211210612_create_user_engaged_projects.rb
@@ -1,10 +1,10 @@
 class CreateUserEngagedProjects < ActiveRecord::Migration
   def change
     create_table :user_engaged_projects do |t|
-      t.string      :project_github_url, null: false
-      t.string      :engagement_type,    null: false
-      t.datetime    :github_created_at,  null: false
-      t.references  :user,               null: false
+      t.string :project_github_url,     null: false
+      t.string :engagement_type,        null: false
+      t.datetime :github_created_at,    null: false
+      t.references :user,               null: false
       t.timestamps
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150209221313) do
+ActiveRecord::Schema.define(:version => 20150211210612) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "namespace"
@@ -201,6 +201,18 @@ ActiveRecord::Schema.define(:version => 20150209221313) do
   end
 
   add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
+
+  create_table "user_engaged_projects", :force => true do |t|
+    t.string   "project_github_url", :null => false
+    t.string   "engagement_type",    :null => false
+    t.datetime "github_created_at",  :null => false
+    t.integer  "user_id",            :null => false
+    t.datetime "created_at",         :null => false
+    t.datetime "updated_at",         :null => false
+  end
+
+  add_index "user_engaged_projects", ["project_github_url"], :name => "index_user_engaged_projects_on_project_github_url"
+  add_index "user_engaged_projects", ["user_id"], :name => "index_user_engaged_projects_on_user_id"
 
   create_table "user_profiles", :force => true do |t|
     t.integer  "user_id",                            :null => false


### PR DESCRIPTION
This is a starting place for tracking user projects that have been selected / worked on during events beyond the featured projects. Eventually (soon) it will hook up to the `Github` service object and turn `User` GitHub API results into `user.user_engaged_projects` records.

I full expect this table to change - perhaps drastically - as we start to find our use cases for this data.

Because I'm not quite sure how it's going to fit into the broader scheme of things, `UserEngagedProject` is only tied to the `User` object, while it holds a `:project_github_url` for future comparison purposes. This is going to mean each individual result is going to create a new record, regardless of whether the project is already captured in our database. And, if precautions aren't taken, regardless of whether it's already been run & captured.