### PR TITLE
Events nav dropdown now holds upcoming events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,9 @@ class ApplicationController < ActionController::Base
   end
 
   def nav_events
-    @nav_events = Event.upcoming_events.public_events.order('start_date').take(4)
+    @nav_events = Event.upcoming_events.
+                        public_events.
+                        order("start_date").
+                        take(4)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  before_filter :force_www!
+  before_filter :force_www!, :nav_events
 
   def after_sign_in_path_for(resource)
     dashboard_path
@@ -37,5 +37,9 @@ class ApplicationController < ActionController::Base
 
   def current_event
     @current_event = Event.current
+  end
+
+  def nav_events
+    @nav_events = Event.upcoming_events.public_events.order('start_date').take(4)
   end
 end

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -16,6 +16,11 @@
         <li><%= link_to "Jobs", jobs_path %></li>
         <li class="has-dropdown"><%= link_to "Events", events_path %>
           <ul class="dropdown">
+            <% if @nav_events %>
+              <% @nav_events.each do |nav_event| %>
+                <li><%= link_to nav_event.name, event_path(nav_event) %></li>
+              <% end %>
+            <% end %>
             <li><%= link_to "Women Coders Dinner", 'https://www.codemontage.com/events/amplify-women-coders-dinner' %></li>
             <li><%= link_to "Coder Day of Service", coder_day_path %></li>
             <li><%= link_to "NYC Meetup", "http://meetup.com/Developers-for-Good", :target => "_blank" %></li>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -21,8 +21,7 @@
                 <li><%= link_to nav_event.name, event_path(nav_event) %></li>
               <% end %>
             <% end %>
-            <li><%= link_to "Women Coders Dinner", 'https://www.codemontage.com/events/amplify-women-coders-dinner' %></li>
-            <li><%= link_to "Coder Day of Service", coder_day_path %></li>
+            <li><%= link_to "Past Events", events_path %></li>
             <li><%= link_to "NYC Meetup", "http://meetup.com/Developers-for-Good", :target => "_blank" %></li>
             <li><%= link_to "WriteSpeakCode Conf", "http://writespeakcode.com", :target => "_blank" %></li>
           </ul>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -22,8 +22,6 @@
               <% end %>
             <% end %>
             <li><%= link_to "Past Events", events_path %></li>
-            <li><%= link_to "NYC Meetup", "http://meetup.com/Developers-for-Good", :target => "_blank" %></li>
-            <li><%= link_to "WriteSpeakCode Conf", "http://writespeakcode.com", :target => "_blank" %></li>
           </ul>
         </li>
         <li><%= link_to "Our Story", our_story_path %></li>


### PR DESCRIPTION
An easy way to find upcoming events -- the nav bar!

Not sure about adding this database-dependent `before_filter` to every controller - if it creates unnecessary noise - but it works!

*Nav bar with upcoming events*
![screenshot 2015-02-12 16 31 58](https://cloud.githubusercontent.com/assets/2766324/6177532/a3ae60ca-b2d5-11e4-9e5b-906a5d0d01a3.png)
