### PR TITLE
Enforce ssl for staging environment

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -32,7 +32,7 @@ CodeMontage::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug


### PR DESCRIPTION
A slight change that should use Heroku's built-in SSL certificate in staging, to better match production environment.