### PR TITLE
Adding project requirements page, fixes #341.

### DIFF
--- a/app/views/home/project_requirements.html.erb
+++ b/app/views/home/project_requirements.html.erb
@@ -1,0 +1,38 @@
+<div id="project_requirements">
+  <div class="row">
+    <h2>Project Requirements</h2>
+    <p>Wanting to partner with CodeMontage and become one of our <%= link_to "featured projects", projects_path %>? Here are some guidelines we look for and simple suggestions on what we consider best practices for all of our projects.</p>
+  </div>
+  <div class="row" id="open_source">
+    <h3>Open Source</h3>
+    <p>At CodeMontage, we strive for the projects we work on to have as much transparency to the public as possible. This leads us to make open source projects a requirement for any of our featured projects.</p>
+    <p><strong>What is considered an open source project?</strong>  Open source software is software that can be freely viewed, used, changed, and shared (in modified or unmodified form) by anyone.</p>
+  </div>
+  <div class="row" id="leadership">
+    <h3>Leadership</h3>
+    <p>The most successful open source projects have stemmed from a healthy community surrounding it. Some of these projects may have a specific foundation (e.g. jQuery, Django) that supplies the leadership to help maintain the code base. We do not require that a project have a foundation or larger organization surround the project, but merely a consistent group (or individual) who helps keep the project fresh and serves as the main point of contact.</p>
+  </div>
+  <div class="row" id="issue_tracker">
+    <h3>Issue Tracker</h3>
+    <p>Being able to organize and track issues surrounding the development of a project is a great way to help onboard new developers. GitHub issues, Trac and other systems are acceptable forms of issue management. We require this so that our members are better able to understand how to contribute to the code base.</p>
+  </div>
+  <div class="row" id="up_to_date">
+    <h3>Up-To-Date Code Base</h3>
+    <p>Consistent management of the code base helps a project stay fresh and well organized. If a project has not been committed to in six months or over, CodeMontage considers it a stale project and is not considered something our members can easily contribute to. However, there may be exceptions to this and project owners are welcome to connect with us at <%= mail_to "projects@codemontage.com", "projects@codemontage.com", :subject => "Connecting with CodeMontage", :target => '_blank' %> to discuss further.</p>
+  </div>
+  <div class="row" id="licensing">
+    <h3>Licensing</h3>
+    <p>Choosing a license for your open source project is a crucial part to becoming a solid code base. It helps direct users how they are legally able to use and distribute the code in the project. We request that all projects have a license in order for us to recommend it to our members. Here is a helpful link that explains some of the more popular licensing options: <%= link_to "http://choosealicense.com/", "http://choosealicense.com/" %>.</p>
+    <p>
+      <em>DISCLAIMER: We are not lawyers. Please consult legal counsel regarding questions about these licensing options.</em>
+    </p>
+  </div>
+  <div class="row" id="social_impact">
+    <h3>Social Impact</h3>
+    <p>CodeMontage’s mission is to “improve yourself while improving the world.” Within this context, we require that our featured projects have a direct social impact on the world and help further the advancement of various aspects of the human race, the planet and social good throughout the world. It is our goal to focus on featured projects who provide this level of impact either directly or indirectly to the global community.</p>
+  </div>
+  <div class="row">
+    <h5>Questions?</h5>
+    <p>Feel free to reach out to us at <%= mail_to "projects@codemontage.com", "projects@codemontage.com", :subject => "CodeMontage Project Requirement Questions", :target => '_blank' %>. We look forward to hearing from you!</p>
+  </div>
+</div>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -12,7 +12,12 @@
     </ul>
     <section class="top-bar-section">
       <ul class="left">
-        <li><%= link_to "Projects", projects_path %></li>
+        <li class="has-dropdown">
+          <%= link_to "Projects", projects_path %>
+          <ul class="dropdown">
+            <li><%= link_to "Project Requirements", project_requirements_path %></li>
+          </ul>
+        </li>
         <li><%= link_to "Jobs", jobs_path %></li>
         <li class="has-dropdown"><%= link_to "Events", events_path %>
           <ul class="dropdown">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ CodeMontage::Application.routes.draw do
   get '/our_services', controller: 'home', action: 'services'
   get '/resources', controller: 'home', action: 'resources'
   get '/training', controller: 'home', action: 'training'
+  get '/project_requirements', controller: 'home',
+                               action: 'project_requirements'
 
   # Blog
   get '/blog' => redirect('http://blog.codemontage.com')


### PR DESCRIPTION
This also includes the addition of a link to this on the main nav. Not 100% sure that we want to do this or not, but will leave it up to the team to decide how to move forward.

I'd also like to see a link on `/projects` that references this page somehow. I started incorporating that on this PR, but then decided it was a bit out of scope. Let me know if you'd like me to open another issue with this specific addition. :space_invader: 

Also, let me know if you want screenshots too!