### PR TITLE
Allow event logos to be deleted

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  before_save :delete_logo
+
   has_many :event_registrations
   has_many :sponsors, through: :sponsorships, source: :organization
   has_many :sponsorships


### PR DESCRIPTION
Fixes #301.

__*before delete*__
![screenshot 2015-02-18 00 09 41](https://cloud.githubusercontent.com/assets/2766324/6242744/ca02b538-b702-11e4-80aa-a0663cc4e442.png)

__*after delete*__
![](https://www.evernote.com/shard/s207/sh/d1cd4e4d-6d06-45cc-9521-803c17a16ace/53e698d78da0d8591c89bfed8bf89dd9/deep/0/An-Alternative-Future---Code-Montage.png)