### PR TITLE
Update language for past events - for Add date logic to update language when an Event passed #343

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -7,3 +7,7 @@
 .check-in {
   margin-top:25px;
 }
+
+.top-25 {
+  padding-top: 25px;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,8 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.public_events.order("start_date desc")
+    @upcoming_events = Event.upcoming_events.public_events.order("start_date desc")
+    @past_events = Event.past_events.public_events.order("start_date desc")
   end
 
   def show

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  before_save :delete_logo
+
   has_many :event_registrations
   has_many :sponsors, through: :sponsorships, source: :organization
   has_many :sponsorships

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,7 +27,7 @@ class Event < ActiveRecord::Base
   friendly_id :name, use: :slugged
 
   scope :upcoming_events, -> { where("end_date >= ?", Time.now) }
-  scope :past_events, -> { where("start_date < ?", Time.now) }
+  scope :past_events, -> { where("end_date < ?", Time.now) }
   scope :public_events, -> { where(is_public: true) }
 
   def self.featured
@@ -86,11 +86,11 @@ class Event < ActiveRecord::Base
   end
 
   def upcoming?
-    true if self.start_date > Time.now
+    true if end_date >= Time.now
   end
 
   def past?
-    true if self.start_date < Time.now
+    true if end_date < Time.now
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,6 +27,7 @@ class Event < ActiveRecord::Base
   friendly_id :name, use: :slugged
 
   scope :upcoming_events, -> { where("end_date >= ?", Time.now) }
+  scope :past_events, -> { where("start_date < ?", Time.now) }
   scope :public_events, -> { where(is_public: true) }
 
   def self.featured
@@ -82,6 +83,14 @@ class Event < ActiveRecord::Base
     stats[:total] = total_github_stats
 
     stats
+  end
+
+  def upcoming?
+    true if self.start_date > Time.now
+  end
+
+  def past?
+    true if self.start_date < Time.now
   end
 
   private

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,7 +14,7 @@
         <% end %>
 
         <% if @past_events.present? %>
-          <h4 style="padding-top: 25px;">Past Events</h4>
+          <h4 class="top-25">Past Events</h4>
 
           <% @past_events.each do |event| %>
           <div class="large-10 centered">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,15 +2,26 @@
   <div>
     <h4>Events</h4>
 
-    <% if @events.present? %>
+    <% if @upcoming_events.present? %>
       <p>Join us online or in-person at these upcoming events to build open source and change the world:</p>
 
       <div class="events">
-        <% @events.each do |event| %>
+        <% @upcoming_events.each do |event| %>
           <div class="large-10 centered">
             <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
           </div>
 
+        <% end %>
+
+        <% if @past_events.present? %>
+          <h4 style="padding-top: 25px;">Past Events</h4>
+
+          <% @past_events.each do |event| %>
+          <div class="large-10 centered">
+            <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
+          </div>
+
+          <% end %>
         <% end %>
       </div>
     <% else %>
@@ -23,3 +34,4 @@
     <%= render "check_in_prompt" %>
   <% end %>
 </div>
+

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,18 +9,24 @@
 
       <div id="event_rsvp_top" class="row">
         <div class="large-10 columns large-centered text-center">
-          <%= %>
-          <% if @event.eventbrite_url.present? %>
-            <%= link_to "RSVP for the " + @event.name, @event.eventbrite_url, :class => "large index radius button" %>
+          <%=  %>
+          <% if @event.upcoming? %>
+            <% if @event.eventbrite_url.present? %>
+              <%= link_to "RSVP for the " + @event.name, @event.eventbrite_url, :class => "large index radius button" %>
+            <% else %>
+              <%= link_to "Join the " + @event.name, dashboard_path, :class => "large index radius button" %>
+            <% end %>
           <% else %>
-            <%= link_to "Join the " + @event.name, dashboard_path, :class => "large index radius button" %>
+            <%= link_to "Too late! View More Events", events_path, :class => "large index radius button" %>
           <% end %>
         </div>
       </div>
 
-      <div>
-        <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
-      </div>
+      <% if @event.upcoming? %>
+        <div>
+          <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
+        </div>
+      <% end %>
 
       <div class="large-10 columns large-centered text-center">
         <h1><%= @event.name %></h1>
@@ -66,11 +72,15 @@
     <div id="event_rsvp_bottom" class="row">
       <div class="large-6 columns large-centered text-center">
         <%= %>
-        <% if @event.eventbrite_url.present? %>
-          <%= link_to "RSVP for the " + @event.name, @event.eventbrite_url, :class => "large index radius button" %>
-        <% else %>
-          <%= link_to "Join the " + @event.name, dashboard_path, :class => "large index radius button" %>
-        <% end %>
+          <% if @event.upcoming? %>
+            <% if @event.eventbrite_url.present? %>
+              <%= link_to "RSVP for the " + @event.name, @event.eventbrite_url, :class => "large index radius button" %>
+            <% else %>
+              <%= link_to "Join the " + @event.name, dashboard_path, :class => "large index radius button" %>
+            <% end %>
+          <% else %>
+            <%= link_to "Too late! View More Events", events_path, :class => "large index radius button" %>
+          <% end %>
       </div>
     </div>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -26,6 +26,8 @@
         <div>
           <p class="text-center"><strong>Join us <%= @event.start_date.strftime("%B %d, %Y") %> for the </strong></p>
         </div>
+      <% else %>
+          <p class="text-center"><strong><%= @event.start_date.strftime("%B %d, %Y") %></strong></p>
       <% end %>
 
       <div class="large-10 columns large-centered text-center">


### PR DESCRIPTION
I have a branch with these changes here: https://github.com/alexshook/codemontage/tree/update_language_for_past_events
but I'm not totally sure about the language. Here are two screenshots-- let me know about any changes you'd like. 

![events index page](https://cloud.githubusercontent.com/assets/5642827/6313009/10c5ffa4-b963-11e4-8039-2f3d8f4ab058.png)

![events show page for past event](https://cloud.githubusercontent.com/assets/5642827/6313008/10c612c8-b963-11e4-859d-c31680df640f.png)

