### PR TITLE
Switch from errors to alerts so oauth-related flashes will show

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -76,7 +76,7 @@ class ServicesController < ApplicationController
                 sign_in_and_redirect(:user, user)
               end
             else
-              flash[:error] =  service_route.capitalize + ' cannot be used to sign up on CodeMontage as no valid email address has been provided. Please add a public email address or sign up manually. If you already have an account, you can sign in and add ' + service_route.capitalize + ' from your profile.'
+              flash[:alert] =  service_route.capitalize + ' cannot be used to sign up on CodeMontage as no valid email address has been provided. Please add a public email address or sign up manually. If you already have an account, you can sign in and add ' + service_route.capitalize + ' from your profile.'
               redirect_to new_user_session_path
             end
           end
@@ -95,11 +95,11 @@ class ServicesController < ApplicationController
           end
         end
       else
-        flash[:error] =  service_route.capitalize + ' returned invalid data for the user id.'
+        flash[:alert] =  service_route.capitalize + ' returned invalid data for the user id.'
         redirect_to new_user_session_path
       end
     else
-      flash[:error] = 'Error while authenticating via ' + service_route.capitalize + '.'
+      flash[:alert] = 'Error while authenticating via ' + service_route.capitalize + '.'
       redirect_to new_user_session_path
     end
   end


### PR DESCRIPTION
Errors weren't showing before, which kept users from seeing helpful information about having a public email address on GitHub and valuable feedback that their login attempt has occurred.

I can't screenshot this change because I don't have a GitHub account that replicates the login error, but testing flashes in the dashboard verified that `flash[:error]` does not show a result, while `flash[:alert]` shows up in red at the top of the page.

The other option was to add `flash[:error]` to the application layout, but it doesn't have the styling that alerts do, so this seemed like the better option.