### PR TITLE
Configure ActionMailer in staging and production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,19 @@ CodeMontage::Application.configure do
 
   config.action_mailer.default_url_options = { host: 'codemontage.com' }
 
+  config.action_mailer.delivery_method = :smtp
+
+  # Mandrill smtp settings
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["MANDRILL_USERNAME"],
+    password: ENV["MANDRILL_APIKEY"],
+    address: "smtp.mandrillapp.com",
+    port: 587,
+    enable_starttls_auto: true,
+    authentication: :plain,
+    domain: "heroku.com"
+  }
+
   # Code is not reloaded between requests
   config.cache_classes = true
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,6 +5,19 @@ CodeMontage::Application.configure do
 
   config.action_mailer.default_url_options = { host: 'codemontage.com' }
 
+  config.action_mailer.deliver_method = :smtp
+
+  # Mandrill smtp settings
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["MANDRILL_USERNAME"],
+    password: ENV["MANDRILL_PASSWORD"],
+    address: "smtp.mandrillapp.com",
+    port: 587,
+    enable_starttls_auto: true,
+    authentication: :plain,
+    domain: "codemontage.com"
+  }
+
   # Code is not reloaded between requests
   config.cache_classes = true
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,12 +10,12 @@ CodeMontage::Application.configure do
   # Mandrill smtp settings
   config.action_mailer.smtp_settings = {
     user_name: ENV["MANDRILL_USERNAME"],
-    password: ENV["MANDRILL_PASSWORD"],
+    password: ENV["MANDRILL_APIKEY"],
     address: "smtp.mandrillapp.com",
     port: 587,
     enable_starttls_auto: true,
     authentication: :plain,
-    domain: "codemontage.com"
+    domain: "heroku.com"
   }
 
   # Code is not reloaded between requests

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,7 +5,7 @@ CodeMontage::Application.configure do
 
   config.action_mailer.default_url_options = { host: 'codemontage.com' }
 
-  config.action_mailer.deliver_method = :smtp
+  config.action_mailer.delivery_method = :smtp
 
   # Mandrill smtp settings
   config.action_mailer.smtp_settings = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,7 +3,7 @@ GOOGLE_ANALYTICS_TRACKING_CODE = 'UA-12971916-5'
 CodeMontage::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
-  config.action_mailer.default_url_options = { host: 'codemontage.com' }
+  config.action_mailer.default_url_options = { host: "codemontage-staging.herokuapp.com" }
 
   config.action_mailer.delivery_method = :smtp
 


### PR DESCRIPTION
This PR configures ActionMailer in staging and production, fixing #303, as suggested by @escobara (Thanks!).

Successfully requested password recovery email:
![screenshot 2015-04-01 00 23 10](https://cloud.githubusercontent.com/assets/2766324/6934659/0ac1bba4-d806-11e4-9224-0011a50814a2.png)

:heart_eyes: