### PR TITLE
Fix for Past Events Don't Display Without Upcoming Events - Issue#390

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,6 +14,7 @@ class EventsController < ApplicationController
   def index
     @upcoming_events = Event.upcoming_events.public_events.order("start_date desc")
     @past_events = Event.past_events.public_events.order("start_date desc")
+    @public_events = Event.public_events.order("start_date desc")
   end
 
   def show

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,25 +1,32 @@
 <div class="row">
-  <div>
+  <div class="events">
     <h4>Events</h4>
 
-    <% if @upcoming_events.present? %>
-      <p>Join us online or in-person at these upcoming events to build open source and change the world:</p>
+    <% if @public_events.present? %>
+    
+      <div class="upcoming-events">
+        <% if @upcoming_events.present? %>
+          <p>Join us online or in-person at these upcoming events to build open source and change the world:</p>
 
-      <div class="events">
-        <% @upcoming_events.each do |event| %>
-          <div class="large-10 centered">
-            <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
-          </div>
+          <% @upcoming_events.each do |event| %>
+            <div class="large-10 centered">
+              <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
+            </div>
 
+          <% end %>
+        <% else %>
+          <p>There are no upcoming events.</p>
         <% end %>
-
+      </div>
+        
+      <div class="past-events">
         <% if @past_events.present? %>
           <h4 class="top-25">Past Events</h4>
 
           <% @past_events.each do |event| %>
-          <div class="large-10 centered">
-            <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
-          </div>
+            <div class="large-10 centered">
+              <h5><%= link_to event.name + " - " + event.start_date.strftime("%B %d, %Y"), event_path(event) %></h5>
+            </div>
 
           <% end %>
         <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,11 +142,11 @@ ActiveRecord::Schema.define(:version => 20150227190642) do
     t.datetime "updated_at",                                         :null => false
     t.string   "image_url"
     t.string   "twitter",           :limit => 15
-    t.string   "slug"
     t.string   "logo_file_name"
     t.string   "logo_content_type"
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
+    t.string   "slug"
   end
 
   add_index "organizations", ["slug"], :name => "index_organizations_on_slug", :unique => true


### PR DESCRIPTION
Addressing the display issues brought up in #390 

- Added public_events to be used in the events index page
- Rearrange the conditionals to always display past events if there are any

I added in some filler text when there are only past events ("There are no upcoming events.") This makes the page look a little bit better and at least informs the user that this IS a place where they can find upcoming events if there are any.
