### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Welcome to the CodeMontage Platform
+## Welcome to the CodeMontage Platform
 [![Build Status](https://travis-ci.org/CodeMontageHQ/codemontage.png)](https://travis-ci.org/CodeMontageHQ/codemontage)
 
 **[CodeMontage](http://codemontage.com) empowers coders to improve their impact on the world.**
@@ -14,7 +14,7 @@ Join our mission to create superhero coders! You can get involved by taking any 
 5. Reach out to us at hello@codemontage.com.
 
 
-###Development Environment Setup
+### Development Environment Setup
 
 These setup instructions have been tested on Mac OS X, Microsoft Windows 7 with and without Cygwin, and Linux (Ubuntu 10.8.) Installing and running the site
 under Windows with or without Cygwin may be possible with enough environmental modifications, but doing so is outside the scope of this document.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
